### PR TITLE
Update Find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,14 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+import java.util.Objects;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.student.Student;
 import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all students in address book whose name contains any of the argument keywords.
@@ -28,7 +27,7 @@ public class FindCommand extends Command {
             + "and displays them as a list with index numbers.\n"
             + "Example: " + COMMAND_WORD + " n/alice bob charlie" + " d/monday tuesday";
 
-    public static final String MESSAGE_NO_PARAMETERS = "At least one field to find must be provided.";
+    public static final String MESSAGE_NO_PARAMETERS = "At least one field to find must be provided.\n" + MESSAGE_USAGE;
     public static final String MESSAGE_NO_NAME_KEYWORDS = "At least one name keyword to find must be provided.";
     public static final String MESSAGE_NO_SCHEDULE_KEYWORDS = "At least one schedule keyword to find must be provided.";
     private final List<AttributeContainsKeywordsPredicate<?>> predicates;
@@ -57,12 +56,11 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return predicates.equals(otherFindCommand.predicates);
+        return Objects.equals(predicates, otherFindCommand.predicates);
     }
 
     @Override
     public String toString() {
-        System.out.println(new ToStringBuilder(this));
         String str = new ToStringBuilder(this)
                 .add("predicates", predicates)
                 .toString();
@@ -72,6 +70,6 @@ public class FindCommand extends Command {
 
     @Override
     public int hashCode() {
-        return predicates.hashCode();
+        return Objects.hash(predicates);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -62,8 +62,16 @@ public class FindCommand extends Command {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        System.out.println(new ToStringBuilder(this));
+        String str = new ToStringBuilder(this)
                 .add("predicates", predicates)
                 .toString();
+        return str;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return predicates.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,11 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
+
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all students in address book whose name contains any of the argument keywords.
@@ -16,21 +20,27 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_WORD_RANDOM_CASE = "FiNd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose:"
+            + "1. names contain any of the specified KEYWORDS (case-insensitive)"
+            + "Parameters: [n/KEYWORD [MORE_KEYWORDS]]...\n"
+            + "2. schedules contain any of the specified KEYWORDS (case-insensitive)"
+            + "Parameters: [d/KEYWORD [MORE_KEYWORDS]]...\n"
+            + "and displays them as a list with index numbers.\n"
+            + "Example: " + COMMAND_WORD + " n/alice bob charlie" + " d/monday tuesday";
 
-    private final NameContainsKeywordsPredicate predicate;
+    public static final String MESSAGE_NO_PARAMETERS = "At least one field to find must be provided.";
+    public static final String MESSAGE_NO_NAME_KEYWORDS = "At least one name keyword to find must be provided.";
+    public static final String MESSAGE_NO_SCHEDULE_KEYWORDS = "At least one schedule keyword to find must be provided.";
+    private final List<AttributeContainsKeywordsPredicate<?>> predicates;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(List<AttributeContainsKeywordsPredicate<?>> predicates) {
+        this.predicates = predicates;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredStudentList(predicate);
+        model.updateFilteredStudentList(predicates);
         return new CommandResult(
                 String.format(Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW, model.getFilteredStudentList().size()));
     }
@@ -47,13 +57,13 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return predicate.equals(otherFindCommand.predicate);
+        return predicates.equals(otherFindCommand.predicates);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("predicates", predicates)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -20,10 +20,10 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_WORD_RANDOM_CASE = "FiNd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose:"
-            + "1. names contain any of the specified KEYWORDS (case-insensitive)"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose:\n"
+            + "1. names contain any of the specified KEYWORDS (case-insensitive)\n"
             + "Parameters: [n/KEYWORD [MORE_KEYWORDS]]...\n"
-            + "2. schedules contain any of the specified KEYWORDS (case-insensitive)"
+            + "2. schedules contain any of the specified KEYWORDS (case-insensitive)\n"
             + "Parameters: [d/KEYWORD [MORE_KEYWORDS]]...\n"
             + "and displays them as a list with index numbers.\n"
             + "Example: " + COMMAND_WORD + " n/alice bob charlie" + " d/monday tuesday";

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_DAY = new Prefix("d/");
     public static final Prefix PREFIX_SCHEDULE = new Prefix("t/");
     public static final Prefix PREFIX_SUBJECT = new Prefix("s/");
     public static final Prefix PREFIX_RATE = new Prefix("r/");

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -29,7 +29,6 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
-
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY);
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
@@ -41,25 +40,6 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         List<AttributeContainsKeywordsPredicate<?>> predicates = new ArrayList<>();
 
-//        try {
-//            if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
-//                List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
-//                Collection<Days> days = parseDaysForFind(dayKeywords);
-//                predicates.add(new ScheduleContainsKeywordsPredicate(days));
-//            }
-//            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-//                List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
-//                Collection<String> names = parseNameStringsForFind(nameKeywords);
-//                predicates.add(new NameContainsKeywordsPredicate(names));
-//            }
-//            if (predicates.isEmpty()) {
-//                throw new ParseException(
-//                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
-//            }
-//        } catch (ParseException pe) {
-//            throw new ParseException(
-//                    pe.getMessage() , pe);
-//        }
 
         if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
             List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
@@ -70,12 +50,29 @@ public class FindCommandParser implements Parser<FindCommand> {
             List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
             Collection<String> names = parseNameStringsForFind(nameKeywords);
             predicates.add(new NameContainsKeywordsPredicate(names));
-
         }
-
-
-
+        if (predicates.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
+        }
         return new FindCommand(predicates);
+
+//
+//        if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
+//            List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
+//            Collection<Days> days = parseDaysForFind(dayKeywords);
+//            predicates.add(new ScheduleContainsKeywordsPredicate(days));
+//        }
+//        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+//            List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+//            Collection<String> names = parseNameStringsForFind(nameKeywords);
+//            predicates.add(new NameContainsKeywordsPredicate(names));
+//
+//        }
+
+
+
+
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,21 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Days;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.ScheduleContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +28,85 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY);
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_DAY);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        List<AttributeContainsKeywordsPredicate<?>> predicates = new ArrayList<>();
+
+        if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
+            List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
+            Collection<Days> days = parseDaysForFind(dayKeywords);
+            predicates.add(new ScheduleContainsKeywordsPredicate(days));
+        }
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+            Collection<String> names = parseNameStringsForFind(nameKeywords);
+            predicates.add(new NameContainsKeywordsPredicate(names));
+
+        }
+
+        if (predicates.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
+        }
+
+        return new FindCommand(predicates);
     }
+
+    /**
+     * Parses {@code Collection<String> names} into a {@code Set<String>} if {@code names} is non-empty and valid.
+     * @throws ParseException if {@code names} is empty or contains an empty or invalid name string.
+     */
+    private Set<String> parseNameStringsForFind(Collection<String> names) throws ParseException {
+        assert names != null;
+
+        requireNonNull(names);
+
+        if (names.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
+        }
+        if (names.contains("")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
+        }
+
+        return ParserUtil.parseNameStrings(names);
+
+    }
+
+    /**
+     * Parses {@code Collection<String> days} into a {@code Set<Days>} if {@code days} is non-empty.
+     * @throws ParseException if {@code days} is empty or contains an empty or invalid day string.
+     */
+    private Set<Days> parseDaysForFind(Collection<String> days) throws ParseException {
+        assert days != null;
+
+        if (days.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+        }
+        if (days.contains("")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+        }
+
+        return ParserUtil.parseDays(days);
+    }
+
+
+
+
+
+
+
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -41,6 +41,26 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         List<AttributeContainsKeywordsPredicate<?>> predicates = new ArrayList<>();
 
+//        try {
+//            if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
+//                List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
+//                Collection<Days> days = parseDaysForFind(dayKeywords);
+//                predicates.add(new ScheduleContainsKeywordsPredicate(days));
+//            }
+//            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+//                List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+//                Collection<String> names = parseNameStringsForFind(nameKeywords);
+//                predicates.add(new NameContainsKeywordsPredicate(names));
+//            }
+//            if (predicates.isEmpty()) {
+//                throw new ParseException(
+//                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
+//            }
+//        } catch (ParseException pe) {
+//            throw new ParseException(
+//                    pe.getMessage() , pe);
+//        }
+
         if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
             List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
             Collection<Days> days = parseDaysForFind(dayKeywords);
@@ -53,10 +73,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         }
 
-        if (predicates.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
-        }
+
 
         return new FindCommand(predicates);
     }
@@ -90,11 +107,7 @@ public class FindCommandParser implements Parser<FindCommand> {
     private Set<Days> parseDaysForFind(Collection<String> days) throws ParseException {
         assert days != null;
 
-        if (days.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
-        }
-        if (days.contains("")) {
+        if (days.isEmpty() || days.contains("")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -56,23 +56,6 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
         }
         return new FindCommand(predicates);
-
-//
-//        if (argMultimap.getValue(PREFIX_DAY).isPresent()) {
-//            List<String> dayKeywords = argMultimap.getAllValues(PREFIX_DAY);
-//            Collection<Days> days = parseDaysForFind(dayKeywords);
-//            predicates.add(new ScheduleContainsKeywordsPredicate(days));
-//        }
-//        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-//            List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
-//            Collection<String> names = parseNameStringsForFind(nameKeywords);
-//            predicates.add(new NameContainsKeywordsPredicate(names));
-//
-//        }
-
-
-
-
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,10 +2,15 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.Address;
+import seedu.address.model.student.Days;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.OwedAmount;
@@ -49,6 +54,7 @@ public class ParserUtil {
         }
         return new Name(trimmedName);
     }
+
 
     /**
      * Parses a {@code String phone} into a {@code Phone}.
@@ -95,6 +101,22 @@ public class ParserUtil {
         return new Email(trimmedEmail);
     }
 
+    /**
+     * Parses a {@code String day} into a {@code Days}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code day} is invalid.
+     */
+    public static Days parseDay(String day) throws ParseException {
+        requireNonNull(day);
+        assert !day.isEmpty();
+
+        String trimmedDay = day.trim();
+        if (!Days.isValidDay(trimmedDay)) {
+            throw new ParseException(Days.MESSAGE_CONSTRAINTS);
+        }
+        return Days.valueOf(trimmedDay.toUpperCase());
+    }
     /**
      * Parses a {@code String schedule} into an {@code Schedule}.
      * Leading and trailing whitespaces will be trimmed.
@@ -168,4 +190,40 @@ public class ParserUtil {
         }
         return new OwedAmount(trimmedOwedAmount);
     }
+
+    /**
+     * Parses a {@code Collection<String> nameStrings} into a {@code Set<String>}.
+     * Duplicate names will be ignored.
+     *
+     * @throws ParseException if the {@code names} are invalid.
+     */
+    public static Set<String> parseNameStrings(Collection<String> nameStrings) throws ParseException {
+        requireNonNull(nameStrings);
+
+        final Set<String> nameSet = new HashSet<>();
+        for (String name : nameStrings) {
+            nameSet.add(parseName(name).toString());
+        }
+        return nameSet;
+    }
+
+
+    /**
+     * Parses a {@code Collection<String> days} into a {@code Set<Days>}.
+     *
+     * @throws ParseException if the {@code days} are invalid.
+     */
+    public static Set<Days> parseDays(Collection<String> days) throws ParseException {
+        requireNonNull(days);
+
+        final Set<Days> daysSet = new HashSet<>();
+        for (String day : days) {
+            daysSet.add(parseDay(day));
+        }
+        return daysSet;
+    }
+
+
+
+
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -201,15 +200,17 @@ public class ParserUtil {
     public static Set<String> parseNameStrings(Collection<String> nameStrings) throws ParseException {
         requireNonNull(nameStrings);
 
-        // Ensure names are not null and split by whitespace, then filter out empty strings
-        Set<String> nameStringsSet = nameStrings.stream()
-                .flatMap(name -> Set.of(name.split("\\s+")).stream()) // Split each name by whitespace
-                .filter(name -> !name.isEmpty()) // Filter out empty results
-                .collect(Collectors.toSet()); // Collect into a Set to ensure uniqueness
 
         HashSet<String> nameSet = new HashSet<>();
-        for (String name : nameStringsSet) {
-            nameSet.add(name);
+
+        for (String nameString : nameStrings) {
+            // Split by whitespace
+            String[] names = nameString.split("\\s+");
+            for (String name : names) {
+                if (!name.isEmpty()) { // Filter out empty names
+                    nameSet.add(name); // Add to set to ensure uniqueness
+                }
+            }
         }
         return nameSet;
     }
@@ -223,18 +224,17 @@ public class ParserUtil {
     public static Set<Days> parseDays(Collection<String> days) throws ParseException {
         requireNonNull(days);
 
-        // Ensure names are not null and split by whitespace, then filter out empty strings
-        Set<String> dayStringsSet = days.stream()
-                .flatMap(day -> Set.of(day.split("\\s+")).stream()) // Split each name by whitespace
-                .filter(day -> !day.isEmpty()) // Filter out empty results
-                .collect(Collectors.toSet()); // Collect into a Set to ensure uniqueness
-
-        // Convert the set of day strings to a set of Days
         HashSet<Days> daySet = new HashSet<>();
-        for (String day : dayStringsSet) {
-            daySet.add(parseDay(day));
-        }
 
+        for (String dayString : days) {
+            // Split by whitespace
+            String[] dayStrings = dayString.split("\\s+");
+            for (String day : dayStrings) {
+                if (!day.isEmpty()) { // Filter out empty day strings
+                    daySet.add(parseDay(day)); // Convert and add to the set
+                }
+            }
+        }
         return daySet;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -202,10 +202,16 @@ public class ParserUtil {
         requireNonNull(nameStrings);
 
         // Ensure names are not null and split by whitespace, then filter out empty strings
-        return nameStrings.stream()
+        Set<String> nameStringsSet = nameStrings.stream()
                 .flatMap(name -> Set.of(name.split("\\s+")).stream()) // Split each name by whitespace
                 .filter(name -> !name.isEmpty()) // Filter out empty results
                 .collect(Collectors.toSet()); // Collect into a Set to ensure uniqueness
+
+        HashSet<String> nameSet = new HashSet<>();
+        for (String name : nameStringsSet) {
+            nameSet.add(name);
+        }
+        return nameSet;
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -200,11 +201,11 @@ public class ParserUtil {
     public static Set<String> parseNameStrings(Collection<String> nameStrings) throws ParseException {
         requireNonNull(nameStrings);
 
-        final Set<String> nameSet = new HashSet<>();
-        for (String name : nameStrings) {
-            nameSet.add(parseName(name).toString());
-        }
-        return nameSet;
+        // Ensure names are not null and split by whitespace, then filter out empty strings
+        return nameStrings.stream()
+                .flatMap(name -> Set.of(name.split("\\s+")).stream()) // Split each name by whitespace
+                .filter(name -> !name.isEmpty()) // Filter out empty results
+                .collect(Collectors.toSet()); // Collect into a Set to ensure uniqueness
     }
 
 
@@ -216,11 +217,19 @@ public class ParserUtil {
     public static Set<Days> parseDays(Collection<String> days) throws ParseException {
         requireNonNull(days);
 
-        final Set<Days> daysSet = new HashSet<>();
-        for (String day : days) {
-            daysSet.add(parseDay(day));
+        // Ensure names are not null and split by whitespace, then filter out empty strings
+        Set<String> dayStringsSet = days.stream()
+                .flatMap(day -> Set.of(day.split("\\s+")).stream()) // Split each name by whitespace
+                .filter(day -> !day.isEmpty()) // Filter out empty results
+                .collect(Collectors.toSet()); // Collect into a Set to ensure uniqueness
+
+        // Convert the set of day strings to a set of Days
+        HashSet<Days> daySet = new HashSet<>();
+        for (String day : dayStringsSet) {
+            daySet.add(parseDay(day));
         }
-        return daysSet;
+
+        return daySet;
     }
 
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
 
 /**
  * The API of the Model component.
@@ -100,4 +101,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredStudentList(Predicate<Student> predicate);
+
+    /**
+     * Updates the filter of the filtered student list to filter by the given {@code List} of {@code predicate}.
+     * @throws NullPointerException if {@code List} is null.
+     */
+    void updateFilteredStudentList(List<AttributeContainsKeywordsPredicate<?>> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -139,6 +140,18 @@ public class ModelManager implements Model {
     public void updateFilteredStudentList(Predicate<Student> predicate) {
         requireNonNull(predicate);
         filteredStudents.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredStudentList(List<AttributeContainsKeywordsPredicate<?>> predicates) {
+        requireNonNull(predicates);
+
+        Predicate<Student> combinedPredicate = predicates.stream()
+                .map(predicate -> (Predicate<Student>) predicate) // Cast each to Predicate<Student>
+                .reduce(Predicate::or) // combine all predicates using OR
+                .orElse(PREDICATE_SHOW_ALL_STUDENTS); // Default to show all if no predicates are given
+
+        filteredStudents.setPredicate(combinedPredicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/Days.java
+++ b/src/main/java/seedu/address/model/student/Days.java
@@ -4,8 +4,15 @@ package seedu.address.model.student;
  * Represents a set of days in the address book.
  */
 public enum Days {
+
+
     MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
 
+
+    public static final String MESSAGE_CONSTRAINTS = """
+        Days should only contain the following values:
+        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+        """;
     /**
      * Returns true if a given string is a valid day.
      */

--- a/src/main/java/seedu/address/model/student/Schedule.java
+++ b/src/main/java/seedu/address/model/student/Schedule.java
@@ -117,6 +117,15 @@ public class Schedule {
                 && otherSchedule.startTimeValue.isBefore(endTimeValue);
     }
 
+    /**
+     * Determines whether this schedule is on the specified day.
+     * @param day The day to check against.
+     * @return True if this schedule is on the specified day.
+     */
+    public boolean isOn(Days day) {
+        return dayValue == day;
+    }
+
     @Override
     public String toString() {
         return dayValue + " " + startTimeValue + " - " + endTimeValue;

--- a/src/main/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicate.java
@@ -1,0 +1,41 @@
+package seedu.address.model.student.predicates;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s attribute matches any of the keywords given.
+ */
+public abstract class AttributeContainsKeywordsPredicate<T> implements Predicate<Student> {
+    private final Collection<T> keywords;
+
+    public AttributeContainsKeywordsPredicate(Collection<T> keywords) {
+        this.keywords = keywords;
+    }
+
+    public Collection<T> getKeywords() {
+        return keywords;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AttributeContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        AttributeContainsKeywordsPredicate<?> otherPredicate = (AttributeContainsKeywordsPredicate<?>) other;
+        return keywords.equals(otherPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.student.predicates;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
@@ -33,11 +34,16 @@ public class NameContainsKeywordsPredicate extends AttributeContainsKeywordsPred
         }
 
         NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-        return getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
+        return Objects.equals(getKeywords(), otherNameContainsKeywordsPredicate.getKeywords());
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("keywords", getKeywords()).toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKeywords());
     }
 }

--- a/src/main/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicate.java
@@ -1,25 +1,24 @@
-package seedu.address.model.student;
+package seedu.address.model.student.predicates;
 
-import java.util.List;
-import java.util.function.Predicate;
+import java.util.Collection;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.student.Student;
 
 /**
  * Tests that a {@code Student}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Student> {
-    private final List<String> keywords;
+public class NameContainsKeywordsPredicate extends AttributeContainsKeywordsPredicate<String> {
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public NameContainsKeywordsPredicate(Collection<String> keywords) {
+        super(keywords);
     }
 
     @Override
     public boolean test(Student student) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getName().fullName, keyword));
+        return getKeywords().stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getName().toString(), keyword));
     }
 
     @Override
@@ -34,11 +33,11 @@ public class NameContainsKeywordsPredicate implements Predicate<Student> {
         }
 
         NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+        return getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this).add("keywords", getKeywords()).toString();
     }
 }

--- a/src/main/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.student.predicates;
+
+import java.util.Collection;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.student.Days;
+import seedu.address.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s {@code Name} matches any of the keywords given.
+ */
+public class ScheduleContainsKeywordsPredicate extends AttributeContainsKeywordsPredicate<Days> {
+
+    public ScheduleContainsKeywordsPredicate(Collection<Days> keywords) {
+        super(keywords);
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return getKeywords().stream()
+                .anyMatch(keyword -> student.getSchedule().isOn(keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ScheduleContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        ScheduleContainsKeywordsPredicate otherScheduleContainsKeywordsPredicate = (
+                ScheduleContainsKeywordsPredicate) other;
+        return getKeywords().equals(otherScheduleContainsKeywordsPredicate.getKeywords());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", getKeywords()).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.student.predicates;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.student.Days;
@@ -34,11 +35,20 @@ public class ScheduleContainsKeywordsPredicate extends AttributeContainsKeywords
 
         ScheduleContainsKeywordsPredicate otherScheduleContainsKeywordsPredicate = (
                 ScheduleContainsKeywordsPredicate) other;
-        return getKeywords().equals(otherScheduleContainsKeywordsPredicate.getKeywords());
+        return Objects.equals(getKeywords(), otherScheduleContainsKeywordsPredicate.getKeywords());
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("keywords", getKeywords()).toString();
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKeywords());
+    }
+
 }
+
+
+

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -71,6 +71,7 @@ public class AddCommandTest {
     }
 
 
+
     @Test
     public void equals() {
         Student alice = new StudentBuilder().withName("Alice").build();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
 import seedu.address.testutil.StudentBuilder;
 
 public class AddCommandTest {
@@ -182,6 +183,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredStudentList(Predicate<Student> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredStudentList(List<AttributeContainsKeywordsPredicate<?>> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -14,7 +14,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -23,8 +22,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -15,13 +15,15 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
 
@@ -146,7 +148,8 @@ public class CommandTestUtil {
 
         Student student = model.getFilteredStudentList().get(targetIndex.getZeroBased());
         final String[] splitName = student.getName().fullName.split("\\s+");
-        model.updateFilteredStudentList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        HashSet<String> nameSet = new HashSet<>(Collections.singletonList(splitName[0]));
+        model.updateFilteredStudentList(new NameContainsKeywordsPredicate(nameSet));
 
         assertEquals(1, model.getFilteredStudentList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalStudents.CARL;
 import static seedu.address.testutil.TypicalStudents.DANIEL;
 import static seedu.address.testutil.TypicalStudents.ELLE;
 import static seedu.address.testutil.TypicalStudents.FIONA;
-import static seedu.address.testutil.TypicalStudents.GEORGE;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -6,11 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalStudents.CARL;
+import static seedu.address.testutil.TypicalStudents.DANIEL;
 import static seedu.address.testutil.TypicalStudents.ELLE;
 import static seedu.address.testutil.TypicalStudents.FIONA;
 import static seedu.address.testutil.TypicalStudents.GEORGE;
-import static seedu.address.testutil.TypicalStudents.HOON;
-import static seedu.address.testutil.TypicalStudents.IDA;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -93,25 +92,16 @@ public class FindCommandTest {
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredStudentList());
     }
     @Test
-    public void execute_scheduleOnSaturday_multipleStudentsFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 4);
+    public void execute_scheduleOnWednesday_oneStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
 
-        FindCommand command = new FindCommand(List.of(prepareSchedulePredicate(Days.SATURDAY)));
+        ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.WEDNESDAY);
+
+        FindCommand command = new FindCommand(List.of(schedulePredicate));
         expectedModel.updateFilteredStudentList(List.of(schedulePredicate));
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(FIONA, GEORGE, HOON, IDA), model.getFilteredStudentList());
-    }
-
-    @Test
-    public void execute_scheudleOnSunday_noStudentFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
-
-        FindCommand command = new FindCommand(List.of(prepareSchedulePredicate(Days.SUNDAY)));
-        expectedModel.updateFilteredStudentList(List.of(prepareSchedulePredicate(Days.SUNDAY)));
-
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+        assertEquals(Collections.singletonList(DANIEL), model.getFilteredStudentList());
     }
 
     @Test
@@ -122,7 +112,7 @@ public class FindCommandTest {
         expectedModel.updateFilteredStudentList(List.of(schedulePredicate));
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(ELLE, FIONA), model.getFilteredStudentList());
+        assertEquals(Arrays.asList(DANIEL, FIONA), model.getFilteredStudentList());
     }
 
     @Test
@@ -136,14 +126,15 @@ public class FindCommandTest {
         expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE), model.getFilteredStudentList());
+        assertEquals(Arrays.asList(DANIEL, ELLE), model.getFilteredStudentList());
     }
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(List.of(namePredicate, schedulePredicate));
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        List<AttributeContainsKeywordsPredicate<?>> predicates = List.of(namePredicate, schedulePredicate);
+
+        FindCommand findCommand = new FindCommand(predicates);
+        String expected = FindCommand.class.getCanonicalName() + "{predicates=" + predicates + "}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -8,40 +8,56 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalStudents.CARL;
 import static seedu.address.testutil.TypicalStudents.ELLE;
 import static seedu.address.testutil.TypicalStudents.FIONA;
+import static seedu.address.testutil.TypicalStudents.GEORGE;
+import static seedu.address.testutil.TypicalStudents.HOON;
+import static seedu.address.testutil.TypicalStudents.IDA;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Days;
+import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.ScheduleContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
+    private static NameContainsKeywordsPredicate emptyNamePredicate;
+    private static NameContainsKeywordsPredicate namePredicate;
+    private static ScheduleContainsKeywordsPredicate schedulePredicate;
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+
+    @BeforeAll
+    public static void setUp() {
+        emptyNamePredicate = prepareNamePredicate(" ");
+        namePredicate = prepareNamePredicate("Kurz Elle Kunz");
+        schedulePredicate = prepareSchedulePredicate(Days.WEDNESDAY, Days.FRIDAY);
+    }
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        List<AttributeContainsKeywordsPredicate<?>> firstPredicateList = List.of(namePredicate);
+        List<AttributeContainsKeywordsPredicate<?>> secondPredicateList = List.of(schedulePredicate);
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicateList);
+        FindCommand findSecondCommand = new FindCommand(secondPredicateList);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicateList);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -50,34 +66,83 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different student -> returns false
+        // different predicate -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 
     @Test
-    public void execute_zeroKeywords_noStudentFound() {
+    public void execute_zeroNameKeywords_noStudentFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredStudentList(predicate);
+
+        FindCommand command = new FindCommand(List.of(emptyNamePredicate));
+        expectedModel.updateFilteredStudentList(List.of(emptyNamePredicate));
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredStudentList());
     }
 
     @Test
-    public void execute_multipleKeywords_multipleStudentsFound() {
+    public void execute_multipleNameKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredStudentList(predicate);
+
+
+        FindCommand command = new FindCommand(List.of(namePredicate));
+        expectedModel.updateFilteredStudentList(List.of(namePredicate));
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredStudentList());
+    }
+    @Test
+    public void execute_scheduleOnSaturday_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 4);
+
+        FindCommand command = new FindCommand(List.of(prepareSchedulePredicate(Days.SATURDAY)));
+        expectedModel.updateFilteredStudentList(List.of(schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(FIONA, GEORGE, HOON, IDA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_scheudleOnSunday_noStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
+
+        FindCommand command = new FindCommand(List.of(prepareSchedulePredicate(Days.SUNDAY)));
+        expectedModel.updateFilteredStudentList(List.of(prepareSchedulePredicate(Days.SUNDAY)));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleScheduleKeywords_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
+
+        FindCommand command = new FindCommand(List.of(schedulePredicate));
+        expectedModel.updateFilteredStudentList(List.of(schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ELLE, FIONA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_nameAndScheduleKeywords_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
+
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
+        ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.WEDNESDAY);
+
+        FindCommand command = new FindCommand(List.of(namePredicate, schedulePredicate));
+        expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, ELLE), model.getFilteredStudentList());
     }
 
     @Test
     public void toStringMethod() {
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate);
+        FindCommand findCommand = new FindCommand(List.of(namePredicate, schedulePredicate));
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
     }
@@ -85,7 +150,14 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private static NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code days} into a {@code ScheduleContainsKeywordsPredicate}.
+     */
+    private static ScheduleContainsKeywordsPredicate prepareSchedulePredicate(Days... days) {
+        return new ScheduleContainsKeywordsPredicate(Arrays.stream(days).toList());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -10,7 +10,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -110,22 +112,22 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         // keywords for each prefix
-        List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
-        List<String> dayKeywords = Arrays.asList("Monday", "Tuesday", "Wednesday");
+        Collection<String> nameKeywords = Set.of("foo", "bar", "baz");
+        Collection<String> dayKeywords = Set.of("Monday", "Tuesday", "Wednesday");
 
         // Collection of keyword for day
-        List<Days> daySet = Arrays.asList(Days.MONDAY, Days.TUESDAY, Days.WEDNESDAY);
+        Collection<Days> daySet = Set.of(Days.MONDAY, Days.TUESDAY, Days.WEDNESDAY);
 
         // Predicates for prefixes
         NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(nameKeywords);
         ScheduleContainsKeywordsPredicate dayPredicate = new ScheduleContainsKeywordsPredicate(daySet);
-        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicate, dayPredicate));
+        FindCommand expectedFindCommand = new FindCommand(List.of(dayPredicate, namePredicate));
 
         // Constructing the input string
         String nameInput = PREFIX_NAME + String.join(" ", nameKeywords);
         String dayInput = PREFIX_DAY + String.join(" ", dayKeywords);
         String userInput = FindCommand.COMMAND_WORD + " " + nameInput + " " + dayInput;
-        String userInputRandomCase = FindCommand.COMMAND_WORD_RANDOM_CASE + " " + nameInput + " " + dayInput;
+        String userInputRandomCase = FindCommand.COMMAND_WORD_RANDOM_CASE + " " + dayInput + " " + nameInput;
 
         // Parsing the input string
         FindCommand command = (FindCommand) parser.parseCommand(userInput);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,12 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +25,10 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.IncomeCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Days;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.ScheduleContainsKeywordsPredicate;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.StudentUtil;
@@ -106,19 +109,31 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
-    }
+        // keywords for each prefix
+        List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
+        List<String> dayKeywords = Arrays.asList("Monday", "Tuesday", "Wednesday");
 
-    @Test
-    public void parseCommand_findRandomCase() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD_RANDOM_CASE + " "
-                        + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        // Collection of keyword for day
+        List<Days> daySet = Arrays.asList(Days.MONDAY, Days.TUESDAY, Days.WEDNESDAY);
+
+        // Predicates for prefixes
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(nameKeywords);
+        ScheduleContainsKeywordsPredicate dayPredicate = new ScheduleContainsKeywordsPredicate(daySet);
+        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicate, dayPredicate));
+
+        // Constructing the input string
+        String nameInput = PREFIX_NAME + String.join(" ", nameKeywords);
+        String dayInput = PREFIX_DAY + String.join(" ", dayKeywords);
+        String userInput = FindCommand.COMMAND_WORD + " " + nameInput + " " + dayInput;
+        String userInputRandomCase = FindCommand.COMMAND_WORD_RANDOM_CASE + " " + nameInput + " " + dayInput;
+
+        // Parsing the input string
+        FindCommand command = (FindCommand) parser.parseCommand(userInput);
+        FindCommand commandRandomCase = (FindCommand) parser.parseCommand(userInputRandomCase);
+
+        // Random case allowed
+        assertEquals(expectedFindCommand, command);
+        assertEquals(expectedFindCommand, commandRandomCase);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -7,7 +7,8 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
@@ -21,9 +22,9 @@ public class FindCommandParserTest {
     private static ScheduleContainsKeywordsPredicate schedulePredicateKeywords;
     private FindCommandParser parser = new FindCommandParser();
 
-    @BeforeEach
-    public void setUp() {
-        namePredicateKeywords = new NameContainsKeywordsPredicate(Arrays.asList("Alice1", "Bob"));
+    @BeforeAll
+    public static void setUp() {
+        namePredicateKeywords = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Alice1"));
         schedulePredicateKeywords = new ScheduleContainsKeywordsPredicate(Arrays.asList(Days.MONDAY, Days.TUESDAY));
     }
 
@@ -37,66 +38,68 @@ public class FindCommandParserTest {
     @Test
     public void parse_emptyNameArgument_throwsParseException() {
         // day argument is present
-        assertParseFailure(parser, "n/  d/Saturday",
+        assertParseFailure(parser, " n/  d/Saturday",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
-        assertParseFailure(parser, "d/Saturday n/ ",
+        assertParseFailure(parser, " d/Saturday n/ ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
 
         // multiple whitespaces
-        assertParseFailure(parser, "n/     ",
+        assertParseFailure(parser, " n/     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
     }
 
     @Test
     public void parse_emptyDayArgumentWithValidNameArgumentInfront_throwsParseException() {
         // name argument is present
-        assertParseFailure(parser, "n/Alice BOB d/    ",
+        assertParseFailure(parser, " n/Alice BOB d/    ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
 
     }
     
-//    @Test
-//    public void parse_emptyDayArgument_throwsParseException() {
-//        assertParseFailure(parser, "d/ n/Alice",
-//                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-//
-////        // multiple whitespaces
-////        assertParseFailure(parser, "d/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
-//
-//    }
-//
-//    @Test
-//    public void parse_validNameArgs_returnsFindCommand() {
-//        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
-//
-//        // alnum characters and extra whitespaces allowed
-//        assertParseSuccess(parser, "n/Alice1      Bob", expectedFindCommand);
-//    }
+    @Test
+    public void parse_emptyDayArgument_throwsParseException() {
+        assertParseFailure(parser, " d/ n/Alice",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+
+        // multiple whitespaces
+        assertParseFailure(parser, " d/     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+
+    }
+
+    @Test
+    public void parse_validNameArgs_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
+
+        // alnum characters and extra whitespaces allowed
+        assertParseSuccess(parser, " n/Alice1      Bob", expectedFindCommand);
+    }
 
     @Test
     public void parse_validDayArgs_returnsFindCommand() {
         FindCommand expectedFindCommand = new FindCommand(List.of(schedulePredicateKeywords));
 
         // random case and extra whitespaces allowed
-        assertParseSuccess(parser, "d/  Monday   tUeSdAy", expectedFindCommand);
+        assertParseSuccess(parser, " d/  Monday   tUeSdAy", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
 
-        FindCommand expectedFindCommand = new FindCommand(List.of(
-                namePredicateKeywords,
-                schedulePredicateKeywords)
+        FindCommand expectedFindCommand = new FindCommand(Arrays.asList(
+                schedulePredicateKeywords,
+                namePredicateKeywords)
         );
 
         // no leading and trailing whitespaces
-        assertParseSuccess(parser, "n/Alice Bob d/Monday Tuesday", expectedFindCommand);
+        assertParseSuccess(parser, " n/Alice1 Bob d/Monday Tuesday", expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " n/\n Alice \n \t Bob  \t d/Monday     Tuesday", expectedFindCommand);
 
         // swapped order of arguments
-        assertParseSuccess(parser, "d/Monday Tuesday n/Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, " d/Monday Tuesday n/Alice Bob", expectedFindCommand);
     }
+
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -6,9 +6,9 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
@@ -24,8 +24,8 @@ public class FindCommandParserTest {
 
     @BeforeAll
     public static void setUp() {
-        namePredicateKeywords = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Alice1"));
-        schedulePredicateKeywords = new ScheduleContainsKeywordsPredicate(Arrays.asList(Days.MONDAY, Days.TUESDAY));
+        namePredicateKeywords = new NameContainsKeywordsPredicate(Set.of("Bob", "Alice1"));
+        schedulePredicateKeywords = new ScheduleContainsKeywordsPredicate(Set.of(Days.MONDAY, Days.TUESDAY));
     }
 
 
@@ -55,7 +55,7 @@ public class FindCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
 
     }
-    
+
     @Test
     public void parse_emptyDayArgument_throwsParseException() {
         assertParseFailure(parser, " d/ n/Alice",
@@ -72,7 +72,7 @@ public class FindCommandParserTest {
         FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
 
         // alnum characters and extra whitespaces allowed
-        assertParseSuccess(parser, " n/Alice1      Bob", expectedFindCommand);
+        assertParseSuccess(parser, " n/Bob Alice1", expectedFindCommand);
     }
 
     @Test
@@ -95,10 +95,10 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, " n/Alice1 Bob d/Monday Tuesday", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " n/\n Alice \n \t Bob  \t d/Monday     Tuesday", expectedFindCommand);
+        assertParseSuccess(parser, " n/\n Alice1 \n \t Bob  \t d/Monday     Tuesday", expectedFindCommand);
 
         // swapped order of arguments
-        assertParseSuccess(parser, " d/Monday Tuesday n/Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, " d/Monday Tuesday n/Alice1 Bob", expectedFindCommand);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -48,16 +48,21 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_emptyDayArgument_throwsParseException() {
+    public void parse_emptyDayArgumentWithValidNameArgumentInfront_throwsParseException() {
         // name argument is present
         assertParseFailure(parser, "n/Alice d/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+
+    }
+    
+    @Test
+    public void parse_emptyDayArgument_throwsParseException() {
         assertParseFailure(parser, "d/  n/Alice",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
 
-        // multiple whitespaces
-        assertParseFailure(parser, "d/     ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+//        // multiple whitespaces
+//        assertParseFailure(parser, "d/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -50,28 +50,28 @@ public class FindCommandParserTest {
     @Test
     public void parse_emptyDayArgumentWithValidNameArgumentInfront_throwsParseException() {
         // name argument is present
-        assertParseFailure(parser, "n/Alice d/",
+        assertParseFailure(parser, "n/Alice BOB d/    ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
 
     }
     
-    @Test
-    public void parse_emptyDayArgument_throwsParseException() {
-        assertParseFailure(parser, "d/  n/Alice",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
-
-//        // multiple whitespaces
-//        assertParseFailure(parser, "d/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
-
-    }
-
-    @Test
-    public void parse_validNameArgs_returnsFindCommand() {
-        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
-
-        // alnum characters and extra whitespaces allowed
-        assertParseSuccess(parser, "n/Alice1      Bob", expectedFindCommand);
-    }
+//    @Test
+//    public void parse_emptyDayArgument_throwsParseException() {
+//        assertParseFailure(parser, "d/ n/Alice",
+//                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+//
+////        // multiple whitespaces
+////        assertParseFailure(parser, "d/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+//
+//    }
+//
+//    @Test
+//    public void parse_validNameArgs_returnsFindCommand() {
+//        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
+//
+//        // alnum characters and extra whitespaces allowed
+//        assertParseSuccess(parser, "n/Alice1      Bob", expectedFindCommand);
+//    }
 
     @Test
     public void parse_validDayArgs_returnsFindCommand() {

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,30 +5,93 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Days;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.ScheduleContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
+    private static NameContainsKeywordsPredicate namePredicateKeywords;
+    private static ScheduleContainsKeywordsPredicate schedulePredicateKeywords;
     private FindCommandParser parser = new FindCommandParser();
 
+    @BeforeEach
+    public void setUp() {
+        namePredicateKeywords = new NameContainsKeywordsPredicate(Arrays.asList("Alice1", "Bob"));
+        schedulePredicateKeywords = new ScheduleContainsKeywordsPredicate(Arrays.asList(Days.MONDAY, Days.TUESDAY));
+    }
+
+
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_emptyInput_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyNameArgument_throwsParseException() {
+        // day argument is present
+        assertParseFailure(parser, "n/  d/Saturday",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
+        assertParseFailure(parser, "d/Saturday n/ ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
+
+        // multiple whitespaces
+        assertParseFailure(parser, "n/     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_NAME_KEYWORDS));
+    }
+
+    @Test
+    public void parse_emptyDayArgument_throwsParseException() {
+        // name argument is present
+        assertParseFailure(parser, "n/Alice d/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+        assertParseFailure(parser, "d/  n/Alice",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+
+        // multiple whitespaces
+        assertParseFailure(parser, "d/     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_SCHEDULE_KEYWORDS));
+    }
+
+    @Test
+    public void parse_validNameArgs_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(List.of(namePredicateKeywords));
+
+        // alnum characters and extra whitespaces allowed
+        assertParseSuccess(parser, "n/Alice1      Bob", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validDayArgs_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(List.of(schedulePredicateKeywords));
+
+        // random case and extra whitespaces allowed
+        assertParseSuccess(parser, "d/  Monday   tUeSdAy", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+
+        FindCommand expectedFindCommand = new FindCommand(List.of(
+                namePredicateKeywords,
+                schedulePredicateKeywords)
+        );
+
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "n/Alice Bob d/Monday Tuesday", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " n/\n Alice \n \t Bob  \t d/Monday     Tuesday", expectedFindCommand);
+
+        // swapped order of arguments
+        assertParseSuccess(parser, "d/Monday Tuesday n/Alice Bob", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.AddressBookBuilder;
 

--- a/src/test/java/seedu/address/model/student/ScheduleTest.java
+++ b/src/test/java/seedu/address/model/student/ScheduleTest.java
@@ -105,6 +105,24 @@ class ScheduleTest {
     }
 
     @Test
+    public void isOn_sameDay_returnsTrue() {
+        Schedule schedule = new Schedule("Monday-0900-1100"); // Monday
+        assertTrue(schedule.isOn(Days.MONDAY), "A schedule should be on the day it is scheduled.");
+    }
+
+    @Test
+    public void isOn_differentDay_returnsFalse() {
+        Schedule schedule = new Schedule("Monday-0900-1100"); // Monday
+        for (Days day : Days.values()) {
+            if (day == Days.MONDAY) {
+                continue;
+            }
+            assertFalse(schedule.isOn(day), "This schedule is not on " + day + ".");
+        }
+
+    }
+
+    @Test
     public void isClash_sameSchedule_returnsTrue() {
         Schedule schedule = new Schedule("Monday-0900-1100"); // Monday
         assertTrue(schedule.isClash(schedule), "A schedule should clash with itself.");

--- a/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
@@ -6,11 +6,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.student.Student;
-
-
-
 
 class AttributeContainsKeywordsPredicateTest {
 

--- a/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.student.Student;
 
 
@@ -35,7 +36,8 @@ class AttributeContainsKeywordsPredicateTest {
         List<String> keywords = List.of("keyword1", "keyword2");
         AttributeContainsKeywordsPredicate<String> predicate = generatePredicate(keywords);
 
-        String expected = AttributeContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        // anonymous class do not have canonical name
+        String expected = "null{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());
     }
 
@@ -45,6 +47,7 @@ class AttributeContainsKeywordsPredicateTest {
             public boolean test(Student student) {
                 return false;
             }
+
         };
     }
 }

--- a/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/AttributeContainsKeywordsPredicateTest.java
@@ -1,0 +1,50 @@
+package seedu.address.model.student.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.student.Student;
+
+
+
+
+class AttributeContainsKeywordsPredicateTest {
+
+    @Test
+    public void getKeywords() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        AttributeContainsKeywordsPredicate<String> predicate = generatePredicate(keywords);
+
+        assertEquals(keywords, predicate.getKeywords());
+    }
+
+    @Test
+    public void equals() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        AttributeContainsKeywordsPredicate<String> predicate = generatePredicate(keywords);
+
+        // same object -> returns true
+        assertEquals(predicate, predicate);
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        AttributeContainsKeywordsPredicate<String> predicate = generatePredicate(keywords);
+
+        String expected = AttributeContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+
+    public AttributeContainsKeywordsPredicate<String> generatePredicate(List<String> keywords) {
+        return new AttributeContainsKeywordsPredicate<String>(keywords) {
+            @Override
+            public boolean test(Student student) {
+                return false;
+            }
+        };
+    }
+}

--- a/src/test/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/NameContainsKeywordsPredicateTest.java
@@ -1,10 +1,11 @@
-package seedu.address.model.student;
+package seedu.address.model.student.predicates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -16,8 +17,8 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        Collection<String> firstPredicateKeywordList = Collections.singletonList("first");
+        Collection<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
         NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
         NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
@@ -82,4 +83,5 @@ public class NameContainsKeywordsPredicateTest {
         String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());
     }
+
 }

--- a/src/test/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicateTest.java
@@ -49,12 +49,12 @@ public class ScheduleContainsKeywordsPredicateTest {
         Collection<Days> firstPredicateKeywordList = Collections.singletonList(Days.MONDAY);
 
         ScheduleContainsKeywordsPredicate predicate = new ScheduleContainsKeywordsPredicate(firstPredicateKeywordList);
-        assertTrue(predicate.test(new StudentBuilder().withSchedule("Alice Bob").build()));
+        assertTrue(predicate.test(new StudentBuilder().withSchedule("Monday-1000-2000").build()));
 
         // Multiple keywords
         Collection<Days> secondPredicateKeywordList = Arrays.asList(Days.MONDAY, Days.TUESDAY);
         predicate = new ScheduleContainsKeywordsPredicate(secondPredicateKeywordList);
-        assertTrue(predicate.test(new StudentBuilder().withSchedule("Alice Bob").build()));
+        assertTrue(predicate.test(new StudentBuilder().withSchedule("Monday-1000-2000").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/predicates/ScheduleContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.address.model.student.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.student.Days;
+import seedu.address.testutil.StudentBuilder;
+
+public class ScheduleContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        Collection<Days> firstPredicateKeywordList = Collections.singletonList(Days.MONDAY);
+        Collection<Days> secondPredicateKeywordList = Arrays.asList(Days.MONDAY, Days.TUESDAY);
+
+        ScheduleContainsKeywordsPredicate
+                firstPredicate = new ScheduleContainsKeywordsPredicate(firstPredicateKeywordList);
+        ScheduleContainsKeywordsPredicate
+                secondPredicate = new ScheduleContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ScheduleContainsKeywordsPredicate
+                firstPredicateCopy = new ScheduleContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different student -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_scheduleContainsKeywords_returnsTrue() {
+        // One keyword
+        Collection<Days> firstPredicateKeywordList = Collections.singletonList(Days.MONDAY);
+
+        ScheduleContainsKeywordsPredicate predicate = new ScheduleContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(predicate.test(new StudentBuilder().withSchedule("Alice Bob").build()));
+
+        // Multiple keywords
+        Collection<Days> secondPredicateKeywordList = Arrays.asList(Days.MONDAY, Days.TUESDAY);
+        predicate = new ScheduleContainsKeywordsPredicate(secondPredicateKeywordList);
+        assertTrue(predicate.test(new StudentBuilder().withSchedule("Alice Bob").build()));
+    }
+
+    @Test
+    public void test_scheduleDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        ScheduleContainsKeywordsPredicate predicate = new ScheduleContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new StudentBuilder().build()));
+
+        // Non-matching keyword
+        predicate = new ScheduleContainsKeywordsPredicate(Collections.singletonList(Days.MONDAY));
+        assertFalse(predicate.test(new StudentBuilder().build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Collection<Days> keywords = Collections.singletonList(Days.MONDAY);
+        ScheduleContainsKeywordsPredicate predicate = new ScheduleContainsKeywordsPredicate(keywords);
+
+        String expected = ScheduleContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -31,27 +31,27 @@ public class TypicalStudents {
 
     public static final Student ALICE = new StudentBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withSchedule("Sunday-1800-1900").withSubject("Economics")
+            .withPhone("94351253").withSchedule("Monday-1800-1900").withSubject("Economics")
             .withRate("250.50").withPaid("0").withOwedAmount("250.50").build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432").withSchedule("Monday-1800-1900")
+            .withEmail("johnd@example.com").withPhone("98765432").withSchedule("Tuesday-1800-1900")
             .withSubject("Mathematics").withRate("100.80").withPaid("201.6").withOwedAmount("0").build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street")
-            .withSchedule("Tuesday-1800-1900").withSubject("Mathematics").withRate("300")
+            .withSchedule("Wednesday-1800-1900").withSubject("Mathematics").withRate("300")
             .withPaid("1200").withOwedAmount("900").build();
     public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street")
-            .withSchedule("Wednesday-1800-1900").withSubject("Mathematics").withRate("450.5")
+            .withSchedule("Thursday-1800-1900").withSubject("Mathematics").withRate("450.5")
             .withPaid("450.5").withOwedAmount("901.00").build();
     public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withPhone("94802224")
             .withEmail("werner@example.com").withAddress("michegan ave")
-            .withSchedule("Thursday-1800-1900").withSubject("Mathematics").withRate("350")
+            .withSchedule("Friday-1800-1900").withSubject("Mathematics").withRate("350")
             .withPaid("2800").withOwedAmount("0").build();
     public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withPhone("94824270")
             .withEmail("lydia@example.com").withAddress("little tokyo")
-            .withSchedule("Friday-1800-1900").withSubject("Mathematics").withRate("260.25")
+            .withSchedule("Saturday-1800-1900").withSubject("Mathematics").withRate("260.25")
             .withPaid("0").withOwedAmount("520.50").build();
     public static final Student GEORGE = new StudentBuilder().withName("George Best").withPhone("94824420")
             .withEmail("anna@example.com").withAddress("4th street").withSchedule("Saturday-1800-1900")
@@ -59,10 +59,10 @@ public class TypicalStudents {
 
     // Manually added
     public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withPhone("84820424")
-            .withEmail("stefan@example.com").withAddress("little india").withSchedule("Sunday-1800-1900")
+            .withEmail("stefan@example.com").withAddress("little india").withSchedule("Saturday-1800-1900")
             .withSubject("Science").withRate("200").withPaid("8000").withOwedAmount("1000").build();
     public static final Student IDA = new StudentBuilder().withName("Ida Mueller").withPhone("84820131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withSchedule("Monday-1800-1900")
+            .withEmail("hans@example.com").withAddress("chicago ave").withSchedule("Saturday-1800-1900")
             .withSubject("Economics").withRate("450").withPaid("900").withOwedAmount("900").build();
 
     // Manually added - Student's details found in {@code CommandTestUtil}

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -31,27 +31,27 @@ public class TypicalStudents {
 
     public static final Student ALICE = new StudentBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withSchedule("Monday-1800-1900").withSubject("Economics")
+            .withPhone("94351253").withSchedule("Sunday-1800-1900").withSubject("Economics")
             .withRate("250.50").withPaid("0").withOwedAmount("250.50").build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432").withSchedule("Tuesday-1800-1900")
+            .withEmail("johnd@example.com").withPhone("98765432").withSchedule("Monday-1800-1900")
             .withSubject("Mathematics").withRate("100.80").withPaid("201.6").withOwedAmount("0").build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street")
-            .withSchedule("Wednesday-1800-1900").withSubject("Mathematics").withRate("300")
+            .withSchedule("Tuesday-1800-1900").withSubject("Mathematics").withRate("300")
             .withPaid("1200").withOwedAmount("900").build();
     public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street")
-            .withSchedule("Thursday-1800-1900").withSubject("Mathematics").withRate("450.5")
+            .withSchedule("Wednesday-1800-1900").withSubject("Mathematics").withRate("450.5")
             .withPaid("450.5").withOwedAmount("901.00").build();
     public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withPhone("94802224")
             .withEmail("werner@example.com").withAddress("michegan ave")
-            .withSchedule("Friday-1800-1900").withSubject("Mathematics").withRate("350")
+            .withSchedule("Thursday-1800-1900").withSubject("Mathematics").withRate("350")
             .withPaid("2800").withOwedAmount("0").build();
     public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withPhone("94824270")
             .withEmail("lydia@example.com").withAddress("little tokyo")
-            .withSchedule("Saturday-1800-1900").withSubject("Mathematics").withRate("260.25")
+            .withSchedule("Friday-1800-1900").withSubject("Mathematics").withRate("260.25")
             .withPaid("0").withOwedAmount("520.50").build();
     public static final Student GEORGE = new StudentBuilder().withName("George Best").withPhone("94824420")
             .withEmail("anna@example.com").withAddress("4th street").withSchedule("Saturday-1800-1900")
@@ -59,10 +59,10 @@ public class TypicalStudents {
 
     // Manually added
     public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withPhone("84820424")
-            .withEmail("stefan@example.com").withAddress("little india").withSchedule("Saturday-1800-1900")
+            .withEmail("stefan@example.com").withAddress("little india").withSchedule("Sunday-1800-1900")
             .withSubject("Science").withRate("200").withPaid("8000").withOwedAmount("1000").build();
     public static final Student IDA = new StudentBuilder().withName("Ida Mueller").withPhone("84820131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withSchedule("Saturday-1800-1900")
+            .withEmail("hans@example.com").withAddress("chicago ave").withSchedule("Monday-1800-1900")
             .withSubject("Economics").withRate("450").withPaid("900").withOwedAmount("900").build();
 
     // Manually added - Student's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Find command can only find names.

This is not helpful for tutors, since they normally would 
check for students on a certain day.

Lets:

1. Update Find command to allow finding using either 
name, or day of a schedule, or both
2. Update CliSyntax to support day parameter 
3. Add in parse utility functions in ParserUtil to help 
parse the inputs of find command
4. Add in a new filter method for model interface, 
which takes in a list of predicates
5. Refactor the predicates classes to be in 
their own predicates package
6. Update the test cases accordingly

Note:
1. Find command now takes in 2 optional parameters n/ and d/, 
but at least one must be supplied
2. Find command is an OR search: it search for all the students 
either one of the arguments supplied
3. Find command now stores a list of predicates instead 
of a single predicate