### PR TITLE
Update Model PUML

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -118,8 +118,7 @@ How the parsing works:
 ### Model component
 **API** : [`Model.java`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/model/Model.java)
 
-<puml src="diagrams/ModelClassDiagram.puml" width="450" />
-
+<puml src="diagrams/ModelClassDiagram.puml" width="800" />
 
 The `Model` component,
 
@@ -132,7 +131,7 @@ The `Model` component,
 
 **Note:** An alternative (arguably, a more OOP) model is given below. It has a `Tag` list in the `AddressBook`, which `Student` references. This allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Student` needing their own `Tag` objects.<br>
 
-<puml src="diagrams/BetterModelClassDiagram.puml" width="450" />
+<puml src="diagrams/BetterModelClassDiagram.puml" width="600" />
 
 </box>
 


### PR DESCRIPTION
Previously, the Model PUML diagram in DG is too small, and it affects readability

Let's
*Increase the size of the PUML diagrams so that it is clearer to the users

**Previously**
![image](https://github.com/user-attachments/assets/c9501456-245e-47b7-9acc-4a5979090831)





**Now**
![image](https://github.com/user-attachments/assets/47987e1d-a897-457e-a9c4-f3f03144a3a0)

and

![image](https://github.com/user-attachments/assets/70fc1205-7b87-44c3-b212-98c0f16bada6)
