### PR TITLE
Update Fee and subclasses constraints

### DIFF
--- a/src/main/java/seedu/address/model/student/Fee.java
+++ b/src/main/java/seedu/address/model/student/Fee.java
@@ -10,8 +10,7 @@ public abstract class Fee {
 
     public static final String MESSAGE_CONSTRAINTS = """
             should adhere to the following constraints:
-            1. is a non negative number
-            2. at most 2 decimal places
+            1. at most 2 decimal places
             """;
 
     public static final String VALIDATION_REGEX = "^[0-9]+(\\.[0-9]{1,2})?$";

--- a/src/main/java/seedu/address/model/student/OwedAmount.java
+++ b/src/main/java/seedu/address/model/student/OwedAmount.java
@@ -6,9 +6,10 @@ import java.util.Objects;
  * Represents a Student's owed tuition fee in the address book.
  */
 public class OwedAmount extends Fee {
+    public static final double MAX_VALUE = 9999999.99;
     public static final String MESSAGE_CONSTRAINTS = "Owed "
             + Fee.MESSAGE_CONSTRAINTS
-            + "2. is non-negative number";
+            + "2. is between the range of 0.00 to " + MAX_VALUE;
 
     /**
      * Constructs a {@code OwedAmount}.
@@ -26,8 +27,16 @@ public class OwedAmount extends Fee {
         super("0");
     }
 
+    /**
+     * Returns true if a given string is a valid owed amount.
+     */
     public static boolean isValidOwedAmount(String test) {
-        return Fee.isValidFee(test);
+        if (!Fee.isValidFee(test)) {
+            return false;
+        }
+
+        double owedAmount = Double.parseDouble(test);
+        return owedAmount >= 0 && owedAmount <= MAX_VALUE;
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/OwedAmount.java
+++ b/src/main/java/seedu/address/model/student/OwedAmount.java
@@ -6,7 +6,9 @@ import java.util.Objects;
  * Represents a Student's owed tuition fee in the address book.
  */
 public class OwedAmount extends Fee {
-    public static final String MESSAGE_CONSTRAINTS = "Owed " + Fee.MESSAGE_CONSTRAINTS;
+    public static final String MESSAGE_CONSTRAINTS = "Owed "
+            + Fee.MESSAGE_CONSTRAINTS
+            + "2. is non-negative number";
 
     /**
      * Constructs a {@code OwedAmount}.
@@ -25,7 +27,7 @@ public class OwedAmount extends Fee {
     }
 
     public static boolean isValidOwedAmount(String test) {
-        return Fee.isValidFee(test);
+        return Fee.isValidFee(test) && Double.parseDouble(test) >= 0;
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/OwedAmount.java
+++ b/src/main/java/seedu/address/model/student/OwedAmount.java
@@ -27,7 +27,7 @@ public class OwedAmount extends Fee {
     }
 
     public static boolean isValidOwedAmount(String test) {
-        return Fee.isValidFee(test) && Double.parseDouble(test) >= 0;
+        return Fee.isValidFee(test);
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/PaidAmount.java
+++ b/src/main/java/seedu/address/model/student/PaidAmount.java
@@ -6,7 +6,9 @@ import java.util.Objects;
  * Represents a Student's paid tuition fee in the address book.
  */
 public class PaidAmount extends Fee {
-    public static final String MESSAGE_CONSTRAINTS = "PaidAmount " + Fee.MESSAGE_CONSTRAINTS;
+    public static final String MESSAGE_CONSTRAINTS = "PaidAmount "
+            + Fee.MESSAGE_CONSTRAINTS
+            + "2. is non-negative number";
 
     /**
      * Constructs a {@code PaidAmount}.

--- a/src/main/java/seedu/address/model/student/PaidAmount.java
+++ b/src/main/java/seedu/address/model/student/PaidAmount.java
@@ -6,9 +6,12 @@ import java.util.Objects;
  * Represents a Student's paid tuition fee in the address book.
  */
 public class PaidAmount extends Fee {
+
+    public static final double MAX_VALUE = 9999999.99;
+
     public static final String MESSAGE_CONSTRAINTS = "PaidAmount "
             + Fee.MESSAGE_CONSTRAINTS
-            + "2. is non-negative number";
+            + "2. is between the range of 0.00 to " + MAX_VALUE;
 
     /**
      * Constructs a {@code PaidAmount}.
@@ -27,8 +30,16 @@ public class PaidAmount extends Fee {
         super("0");
     }
 
+    /**
+     * Returns true if a given string is a valid paid amount.
+     */
     public static boolean isValidPaidAmount(String test) {
-        return Fee.isValidFee(test);
+        if (!Fee.isValidFee(test)) {
+            return false;
+        }
+
+        double paidAmount = Double.parseDouble(test);
+        return paidAmount >= 0 && paidAmount <= MAX_VALUE;
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/Rate.java
+++ b/src/main/java/seedu/address/model/student/Rate.java
@@ -7,7 +7,9 @@ import java.util.Objects;
  */
 public class Rate extends Fee {
 
-    public static final String MESSAGE_CONSTRAINTS = "Rate " + Fee.MESSAGE_CONSTRAINTS;
+    public static final String MESSAGE_CONSTRAINTS = "Rate "
+            + Fee.MESSAGE_CONSTRAINTS
+            + "2. is strictly positive";
 
     /**
     * Constructs a {@code Rate}.
@@ -19,7 +21,7 @@ public class Rate extends Fee {
     }
 
     public static boolean isValidRate(String test) {
-        return Fee.isValidFee(test);
+        return Fee.isValidFee(test) && Double.parseDouble(test) > 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/Rate.java
+++ b/src/main/java/seedu/address/model/student/Rate.java
@@ -6,10 +6,12 @@ import java.util.Objects;
  * Represents a Student's tuition fee rate in the address book.
  */
 public class Rate extends Fee {
+    public static final double MAX_VALUE = 1000.00;
 
     public static final String MESSAGE_CONSTRAINTS = "Rate "
             + Fee.MESSAGE_CONSTRAINTS
-            + "2. is strictly positive";
+            + "2. is between the range of 0.01 to " + MAX_VALUE;
+
 
     /**
     * Constructs a {@code Rate}.
@@ -20,8 +22,16 @@ public class Rate extends Fee {
         super(rate);
     }
 
+    /**
+     * Returns true if a given string is a valid rate.
+     */
     public static boolean isValidRate(String test) {
-        return Fee.isValidFee(test) && Double.parseDouble(test) > 0;
+        if (!Fee.isValidFee(test)) {
+            return false;
+        }
+
+        double rate = Double.parseDouble(test);
+        return rate > 0 && rate <= MAX_VALUE;
     }
 
     @Override

--- a/src/test/java/seedu/address/model/student/OwedAmountTest.java
+++ b/src/test/java/seedu/address/model/student/OwedAmountTest.java
@@ -32,12 +32,14 @@ public class OwedAmountTest {
         assertFalse(OwedAmount.isValidOwedAmount("1.234")); // more than 2 decimal places
         assertFalse(OwedAmount.isValidOwedAmount("1.2.3")); // more than 1 decimal point
         assertFalse(OwedAmount.isValidOwedAmount("-1.23")); // negative number
+        assertFalse(OwedAmount.isValidOwedAmount("10000000.00")); // more than max value
 
         // valid oweds
         assertTrue(OwedAmount.isValidOwedAmount("1")); // 0 decimal places
         assertTrue(OwedAmount.isValidOwedAmount("1.2")); // 1 decimal place
         assertTrue(OwedAmount.isValidOwedAmount("123.23")); // 2 decimal places
         assertTrue(OwedAmount.isValidOwedAmount("0"));
+        assertTrue(OwedAmount.isValidOwedAmount("9999999.99")); // boundary value
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/OwedAmountTest.java
+++ b/src/test/java/seedu/address/model/student/OwedAmountTest.java
@@ -22,7 +22,7 @@ public class OwedAmountTest {
     }
 
     @Test
-    public void isValidOwed() {
+    public void isValidOwedAmount() {
         // null owed
         assertThrows(NullPointerException.class, () -> OwedAmount.isValidOwedAmount(null));
 
@@ -37,7 +37,7 @@ public class OwedAmountTest {
         assertTrue(OwedAmount.isValidOwedAmount("1")); // 0 decimal places
         assertTrue(OwedAmount.isValidOwedAmount("1.2")); // 1 decimal place
         assertTrue(OwedAmount.isValidOwedAmount("123.23")); // 2 decimal places
-        assertTrue(OwedAmount.isValidOwedAmount("0")); // 3 digits
+        assertTrue(OwedAmount.isValidOwedAmount("0"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/PaidAmountTest.java
+++ b/src/test/java/seedu/address/model/student/PaidAmountTest.java
@@ -30,12 +30,14 @@ public class PaidAmountTest {
         assertFalse(PaidAmount.isValidPaidAmount("1.234")); // more than 2 decimal places
         assertFalse(PaidAmount.isValidPaidAmount("1.2.3")); // more than 1 decimal point
         assertFalse(PaidAmount.isValidPaidAmount("-1.23")); // negative number
+        assertFalse(PaidAmount.isValidPaidAmount("10000000.00")); // more than max value
 
         // valid paidAmounts
         assertTrue(PaidAmount.isValidPaidAmount("1")); // 0 decimal places
         assertTrue(PaidAmount.isValidPaidAmount("1.2")); // 1 decimal place
         assertTrue(PaidAmount.isValidPaidAmount("123.23")); // 2 decimal places
         assertTrue(PaidAmount.isValidPaidAmount("0")); // 3 digits
+        assertTrue(PaidAmount.isValidPaidAmount("9999999.99")); // boundary value
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/RateTest.java
+++ b/src/test/java/seedu/address/model/student/RateTest.java
@@ -23,6 +23,7 @@ public class RateTest {
 
     @Test
     void isValidRate() {
+        String maxValueString = Double.toString(Double.MAX_VALUE);
         // null rate
         assertThrows(NullPointerException.class, () -> Rate.isValidRate(null));
 
@@ -32,12 +33,15 @@ public class RateTest {
         assertFalse(Rate.isValidRate("1.234")); // more than 2 decimal places
         assertFalse(Rate.isValidRate("1.2.3")); // more than 1 decimal point
         assertFalse(Rate.isValidRate("-1.23")); // negative number
+        assertFalse(Rate.isValidRate("0")); // 0 rate
+
 
         // valid rates
         assertTrue(Rate.isValidRate("1")); // 0 decimal places
         assertTrue(Rate.isValidRate("1.2")); // 1 decimal place
         assertTrue(Rate.isValidRate("123.23")); // 2 decimal places
-        assertTrue(Rate.isValidRate("0")); // 3 digits
+        assertTrue(Rate.isValidRate("999999999")); // max value
+
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/RateTest.java
+++ b/src/test/java/seedu/address/model/student/RateTest.java
@@ -33,6 +33,7 @@ public class RateTest {
         assertFalse(Rate.isValidRate("1.234")); // more than 2 decimal places
         assertFalse(Rate.isValidRate("1.2.3")); // more than 1 decimal point
         assertFalse(Rate.isValidRate("-1.23")); // negative number
+        assertFalse(Rate.isValidRate("1000.01")); // more than max value
         assertFalse(Rate.isValidRate("0")); // 0 rate
 
 
@@ -40,7 +41,10 @@ public class RateTest {
         assertTrue(Rate.isValidRate("1")); // 0 decimal places
         assertTrue(Rate.isValidRate("1.2")); // 1 decimal place
         assertTrue(Rate.isValidRate("123.23")); // 2 decimal places
-        assertTrue(Rate.isValidRate("999999999")); // max value
+
+        // boundary value
+        assertTrue(Rate.isValidRate("0.01"));
+        assertTrue(Rate.isValidRate("1000")); // boundary value
 
     }
 


### PR DESCRIPTION
`PaidAmount` and `OwedAmount` and `Rate` class does not explicitly state the max value of `9999999.99`. However, when the string parsed in exceeds that, Double.parseDouble and Double.toString will convert it into scientific format, 1000 0000 will be converted to 1E8, which is not a valid string representation of the `Fee` class. Moreover, `Rate` could be 0, which does not make too much sense.

Lets:
* Explicitly check that `PaidAmount` and `OwedAmount` does not exceed that value
* Explicitly check that `Rate` only takes the value between `0.01` and `1000`
* Remind that to the user in the `MESSAGE_CONSTRAINT`

The range that `PaidAmount` and `OwedAmount` and `Rate` can take are sensible amount for an undergraduate that is giving private tuition.

closes #213
closes #229 