### PR TITLE
Update find command to perform and search

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -21,9 +21,9 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all students whose:\n"
             + "1. name contain any of the specified KEYWORDS (case-insensitive)\n"
-            + "Parameters: [n/KEYWORD [MORE_KEYWORDS]]...\n"
+            + "Parameters: [n/KEYWORD [MORE_KEYWORDS...]] AND\n"
             + "2. schedule is on any of the specified DAY keywords (case-insensitive)\n"
-            + "Parameters: [d/DAY [MORE_DAYS]]...\n"
+            + "Parameters: [d/DAY [MORE_DAYS...]]\n"
             + "and displays them as a list with index numbers.\n"
             + "Example: " + COMMAND_WORD + " n/alice bob charlie" + " d/monday tuesday";
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -155,7 +155,7 @@ public class ModelManager implements Model {
 
         Predicate<Student> combinedPredicate = predicates.stream()
                 .map(predicate -> (Predicate<Student>) predicate) // Cast each to Predicate<Student>
-                .reduce(Predicate::or) // combine all predicates using OR
+                .reduce(Predicate::and) // combine all predicates using and
                 .orElse(PREDICATE_SHOW_ALL_STUDENTS); // Default to show all if no predicates are given
 
         filteredStudents.setPredicate(combinedPredicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -105,6 +105,18 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_oneNameWithMultipleScheduleKeywords_oneStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
+
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Daniel");
+        FindCommand command = new FindCommand(List.of(namePredicate, schedulePredicate));
+        expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(DANIEL), model.getFilteredStudentList());
+    }
+
+    @Test
     public void execute_multipleScheduleKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
 
@@ -116,8 +128,8 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_nameAndScheduleKeywords_multipleStudentsFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
+    public void execute_nameAndScheduleKeywords_noStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
 
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
         ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.WEDNESDAY);
@@ -126,7 +138,21 @@ public class FindCommandTest {
         expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(DANIEL, ELLE), model.getFilteredStudentList());
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_nameAndScheduleKeywords_oneStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
+
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
+        ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.THURSDAY);
+
+        FindCommand command = new FindCommand(List.of(namePredicate, schedulePredicate));
+        expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(ELLE), model.getFilteredStudentList());
     }
 
     @Test


### PR DESCRIPTION
Find command finds students whose name contains one of the name keywords provided *OR* their schedule is within one of the days provided. This does not feel intuitive to the user.

Let's update find command to find students whose name contains one of the name keywords provided *AND* their schedule is within one of the days provided.

closes #246 