### PR TITLE
Refactor income command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_HAS_CLASHES = "\nYou have %d other students with clashing schedule:\n%s";
+    public static final String MESSAGE_INCOME = "Total Paid Amount: %.2f   Total Owed Amount: %.2f";
     public static final String MESSAGE_REMINDER = "Reminder(s) for %s:\n";
 
 
@@ -99,6 +100,10 @@ public class Messages {
                         )
                 )
         );
+    }
+
+    public static String getIncomeMessage(double totalPaidAmount, double totalOwedAmount) {
+        return String.format(MESSAGE_INCOME, totalPaidAmount, totalOwedAmount);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/IncomeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/IncomeCommand.java
@@ -2,9 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import javafx.collections.ObservableList;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.student.Student;
 
 
 /**
@@ -18,14 +17,9 @@ public class IncomeCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        double totalOwedAmount = 0;
-        double totalPaidAmount = 0;
-        ObservableList<Student> studentList = model.getFilteredStudentList();
+        double totalPaidAmount = model.getTotalPaidAmount();
+        double totalOwedAmount = model.getTotalOwedAmount();
 
-        for (Student student: studentList) {
-            totalOwedAmount += student.getOwedAmount().value;
-            totalPaidAmount += student.getPaidAmount().value;
-        }
-        return new CommandResult("Total PaidAmount: " + totalPaidAmount + "   Total OwedAmount: " + totalOwedAmount);
+        return new CommandResult(Messages.getIncomeMessage(totalPaidAmount, totalOwedAmount));
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -75,12 +75,14 @@ public interface Model {
     public List<Student> getClashingStudents(Student student);
 
     /**
-     * Retrieves the list of students, adds up their paid amount, and returns the total paid amount
+     * Adds up all the paidAmount from each {@code student} in a list of students
+     * @return total paid amount from the list of students
      */
     public double getTotalPaidAmount();
 
     /**
-     * Retrieves the list of students, adds up their owed amonut, and returns the total owed amount
+     * Adds up all the owedAmount from each {@code student} in a list of students
+     * @return total owed amount from the list of students
      */
     public double getTotalOwedAmount();
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -75,6 +75,16 @@ public interface Model {
     public List<Student> getClashingStudents(Student student);
 
     /**
+     * Retrieves the list of students, adds up their paid amount, and returns the total paid amount
+     */
+    public double getTotalPaidAmount();
+
+    /**
+     * Retrieves the list of students, adds up their owed amonut, and returns the total owed amount
+     */
+    public double getTotalOwedAmount();
+
+    /**
      * Retrieves a list of students with whom {@code student} has lessons on the day.
      * @param day The day to check for.
      * @return List of students scheduled to have lesson on that day.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -109,6 +109,28 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public double getTotalPaidAmount() {
+        double totalPaidAmount = 0;
+        ObservableList<Student> studentList = getFilteredStudentList();
+
+        for (Student student: studentList) {
+            totalPaidAmount += student.getPaidAmountValue();
+        }
+        return totalPaidAmount;
+    }
+
+    @Override
+    public double getTotalOwedAmount() {
+        double totalOwedAmount = 0;
+        ObservableList<Student> studentList = getFilteredStudentList();
+
+        for (Student student: studentList) {
+            totalOwedAmount += student.getOwedAmountValue();
+        }
+        return totalOwedAmount;
+    }
+
+    @Override
     public List<Student> getScheduledStudents(Days day) {
         requireNonNull(day);
         return addressBook.getScheduledStudents(day);

--- a/src/main/java/seedu/address/model/student/OwedAmount.java
+++ b/src/main/java/seedu/address/model/student/OwedAmount.java
@@ -71,6 +71,10 @@ public class OwedAmount extends Fee {
         return value > super.value;
     }
 
+    public double getValue() {
+        return this.value;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/model/student/PaidAmount.java
+++ b/src/main/java/seedu/address/model/student/PaidAmount.java
@@ -53,6 +53,10 @@ public class PaidAmount extends Fee {
         return new PaidAmount(Double.toString(super.value + value));
     }
 
+    public double getValue() {
+        return this.value;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -77,6 +77,14 @@ public class Student {
         return owedAmount;
     }
 
+    public double getPaidAmountValue() {
+        return paidAmount.getValue();
+    }
+
+    public double getOwedAmountValue() {
+        return owedAmount.getValue();
+    }
+
     /**
      * Returns true if both students have the same name.
      * This defines a weaker notion of equality between two students.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -172,6 +172,15 @@ public class AddCommandTest {
         public List<Student> getScheduledStudents(Days day) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public double getTotalPaidAmount() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public double getTotalOwedAmount() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void deleteStudent(Student target) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -50,7 +50,7 @@ public class CommandTestUtil {
     public static final String VALID_RATE_AMY = "250.00";
     public static final String VALID_RATE_BOB = "300.25";
     public static final String VALID_PAID_AMOUNT_AMY = "750.00";
-    public static final String VALID_PAID_AMOUNT_BOB = "0.0";
+    public static final String VALID_PAID_AMOUNT_BOB = "5.0";
     public static final String VALID_OWED_AMOUNT_AMY = "500.00";
     public static final String VALID_OWED_AMOUNT_BOB = "300.25";
     public static final String VALID_HOUR_DESC = " " + PREFIX_HOUR + VALID_HOUR_AMY;

--- a/src/test/java/seedu/address/logic/commands/IncomeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/IncomeCommandTest.java
@@ -25,7 +25,6 @@ public class IncomeCommandTest {
         model.addStudent(validStudent);
         CommandResult commandResult = new IncomeCommand().execute(model);
 
-
         assertEquals(commandResult.getFeedbackToUser(), Messages.getIncomeMessage(validStudent.getPaidAmountValue(),
                 validStudent.getOwedAmountValue()));
 

--- a/src/test/java/seedu/address/logic/commands/IncomeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/IncomeCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.student.Student;
@@ -15,19 +16,18 @@ public class IncomeCommandTest {
     @Test
     public void execute_emptyAddressBook_noPaidAmountNoOwedAmount() {
         CommandResult commandResult = new IncomeCommand().execute(model);
-        assertEquals(commandResult.getFeedbackToUser(), "Total PaidAmount: 0.0   Total OwedAmount: 0.0");
+        assertEquals(commandResult.getFeedbackToUser(), Messages.getIncomeMessage(0, 0));
     }
 
     @Test
-    public void execute_addStudent_showUpdatedPaidAndOwed() {
+    public void execute_addStudent_showUpdatedPaidAmountAndOwedAmount() {
         Student validStudent = new StudentBuilder().build();
         model.addStudent(validStudent);
         CommandResult commandResult = new IncomeCommand().execute(model);
 
-        String expectedOutput = "Total PaidAmount: " + validStudent.getPaidAmount().value
-                + "   Total OwedAmount: " + validStudent.getOwedAmount().value;
 
-        assertEquals(commandResult.getFeedbackToUser(), expectedOutput);
+        assertEquals(commandResult.getFeedbackToUser(), Messages.getIncomeMessage(validStudent.getPaidAmountValue(),
+                validStudent.getOwedAmountValue()));
 
 
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -130,6 +130,28 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getTotalPaidAmount_nullStudent_returnZeroPaidAmount() {
+        assertEquals(modelManager.getTotalPaidAmount(), 0);
+    }
+
+    @Test
+    public void getTotalPaidAmount_someStudents_returnCorrectTotalPaidAmount() {
+        modelManager.addStudent(ALICE);
+        assertEquals(modelManager.getTotalPaidAmount(), ALICE.getPaidAmountValue());
+    }
+
+    @Test
+    public void getTotalOwedAmount_nullStudent_returnZeroPaidAmount() {
+        assertEquals(modelManager.getTotalOwedAmount(), 0);
+    }
+
+    @Test
+    public void getTotalOwedAmount_someStudents_returnCorrectTotalPaidAmount() {
+        modelManager.addStudent(ALICE);
+        assertEquals(modelManager.getTotalOwedAmount(), ALICE.getOwedAmountValue());
+    }
+
+    @Test
     public void getScheduledStudents_nullStudent_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.getScheduledStudents(null));
     }

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -103,14 +103,13 @@ public class StudentTest {
         editedAlice = new StudentBuilder(ALICE).withRate(VALID_RATE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
-        // different owedAmount -> returns false
-        editedAlice = new StudentBuilder(ALICE).withOwedAmount(VALID_OWED_AMOUNT_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
         // different paidAmount -> returns false
         editedAlice = new StudentBuilder(ALICE).withPaidAmount(VALID_PAID_AMOUNT_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
+        // different owedAmount -> returns false
+        editedAlice = new StudentBuilder(ALICE).withOwedAmount(VALID_OWED_AMOUNT_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OWED_AMOUNT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PAID_AMOUNT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SCHEDULE_BOB;
@@ -20,15 +21,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.testutil.StudentBuilder;
 
 public class StudentTest {
-
-    /* seems like it is for tag
-    @Test
-    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
-        Student student = new StudentBuilder().build();
-        assertThrows(UnsupportedOperationException.class, () -> student.getTags().remove(0));
-    }
-    */
-
     @Test
     public void isSameStudent() {
         // same object -> returns true
@@ -40,13 +32,15 @@ public class StudentTest {
         // same name and phone, all other attributes different -> returns true
         Student editedAlice = new StudentBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withSchedule(VALID_SCHEDULE_BOB)
-                .withSubject(VALID_SUBJECT_BOB).withRate(VALID_RATE_BOB).build();
+                .withSubject(VALID_SUBJECT_BOB).withPaidAmount(VALID_PAID_AMOUNT_BOB)
+                .withOwedAmount(VALID_OWED_AMOUNT_BOB).withRate(VALID_RATE_BOB).build();
         assertTrue(ALICE.isSameStudent(editedAlice));
 
         // same name, all other attributes different -> returns false
         editedAlice = new StudentBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withSchedule(VALID_SCHEDULE_BOB)
-                .withSubject(VALID_SUBJECT_BOB).withRate(VALID_RATE_BOB).build();
+                .withSubject(VALID_SUBJECT_BOB).withPaidAmount(VALID_PAID_AMOUNT_BOB)
+                .withOwedAmount(VALID_OWED_AMOUNT_BOB).withRate(VALID_RATE_BOB).build();
         assertFalse(ALICE.isSameStudent(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -111,6 +105,10 @@ public class StudentTest {
 
         // different owedAmount -> returns false
         editedAlice = new StudentBuilder(ALICE).withOwedAmount(VALID_OWED_AMOUNT_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different paidAmount -> returns false
+        editedAlice = new StudentBuilder(ALICE).withPaidAmount(VALID_PAID_AMOUNT_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
     }


### PR DESCRIPTION
Previously, everything was done inside income command, which is not
really good, and it does not abide by the law of demeter as well

Let's
*Refactor the income command so it abides by law of demeter as well as
coding standards

Note: made changes to Messages, IncomeCommand, ModelManager, Student,
OwedAmount and PaidAmount.

For OwedAmount and PaidAmount, since I only added getter methods, did
not add tests for them.
For Student, since there were already tests for getOwedAmount and
getPaidAmount, felt there was no need to test for getOwedAmountValue
and getPaidAmountValue