### PR TITLE
Fix UG link error

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -128,18 +128,18 @@ Adds a student to the address book.
 <box type="tip" header="##### Tips">
 
 
-* New clashing schedule will be informed so that you can modify using the [`edit` command](#editing-a-student--edit).
+* New clashing schedule will be informed so that you can modify using the [`edit` command](#editing-a-student-edit).
 * <b>RATE</b> is the tuition fee per hour.
 * <b>ADDRESS</b> can be used to store place of tuition. E.g. You can store tutee's address if the tuition happens at their place or you can store `My Place` if the tuition is at your place.   
 </box>
 
-### Listing all students : `list`
+### Listing all students: `list`
 
 Shows a list of all students in the address book.
 
 Format: `list`
 
-### Editing a student : `edit`
+### Editing a student: `edit`
 
 Edits an existing student in the address book.
 
@@ -167,7 +167,7 @@ Edits an existing student in the address book.
 
 <box type="tip" header="##### Tips">
 
-* You may refer to [`pay`](#receiving-payment-from-a-student--pay), 
+* You may refer to [`pay`](#receiving-payment-from-a-student-pay), 
 [`owe`](#recording-unpaid-tuition-fee-of-a-student-owe) and [`settle`](#settle-payments-from-students-settle) commands 
 for convenient ways to update the paid amount and owed amount.
 
@@ -216,7 +216,7 @@ Examples:
 </markdown>
 </box>
 
-### Receiving payment from a student : `pay`
+### Receiving payment from a student: `pay`
 
 Updates the amount of tuition fee paid by the specified student after a lesson.
 
@@ -292,7 +292,7 @@ Deletes the specified student from the address book.
 
 </box>
 
-### Getting a reminder for today : `remind`
+### Getting a reminder for today: `remind`
 
 Reminds you of all your lessons scheduled for `today`. UGTeach automatically reminds you when you launch it.
 


### PR DESCRIPTION
Reason for error: extra space before the colon in headings.
Closes #252 #253 