### PR TITLE
Update Find Command to be AND search

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -15,6 +15,8 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.student.Days;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.predicates.AttributeContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.student.predicates.ScheduleContainsKeywordsPredicate;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -147,12 +149,20 @@ public class ModelManager implements Model {
     public void updateFilteredStudentList(List<AttributeContainsKeywordsPredicate<?>> predicates) {
         requireNonNull(predicates);
 
-        Predicate<Student> combinedPredicate = predicates.stream()
-                .map(predicate -> (Predicate<Student>) predicate) // Cast each to Predicate<Student>
-                .reduce(Predicate::or) // combine all predicates using OR
-                .orElse(PREDICATE_SHOW_ALL_STUDENTS); // Default to show all if no predicates are given
+        Predicate<Student> scheduleCombinedPredicate = predicates.stream()
+                .filter(predicate -> predicate instanceof ScheduleContainsKeywordsPredicate)
+                .map(predicate -> (Predicate<Student>) predicate)
+                .reduce(Predicate::or)
+                .orElse(PREDICATE_SHOW_ALL_STUDENTS);
 
-        filteredStudents.setPredicate(combinedPredicate);
+
+        Predicate<Student> nameCombinedPredicate = predicates.stream()
+                .filter(predicate -> predicate instanceof NameContainsKeywordsPredicate)
+                .map(predicate -> (Predicate<Student>) predicate)
+                .reduce(Predicate::or)
+                .orElse(PREDICATE_SHOW_ALL_STUDENTS);
+
+        filteredStudents.setPredicate(scheduleCombinedPredicate.and(nameCombinedPredicate));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -116,8 +116,8 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_nameAndScheduleKeywords_multipleStudentsFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
+    public void execute_nameAndScheduleKeywords_noStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 0);
 
         NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
         ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.WEDNESDAY);
@@ -126,7 +126,21 @@ public class FindCommandTest {
         expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
 
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(DANIEL, ELLE), model.getFilteredStudentList());
+        assertEquals(List.of(), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_nameAndScheduleKeywords_oneStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
+
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
+        ScheduleContainsKeywordsPredicate schedulePredicate = prepareSchedulePredicate(Days.THURSDAY);
+
+        FindCommand command = new FindCommand(List.of(namePredicate, schedulePredicate));
+        expectedModel.updateFilteredStudentList(List.of(namePredicate, schedulePredicate));
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(ELLE), model.getFilteredStudentList());
     }
 
     @Test


### PR DESCRIPTION
Previously, all of the predicates are ORed together but we want to see that with name and schedule predicates, they are AND together instead

Let's
*change find command such that name predicates and schedule predicates are AND together instead