### PR TITLE
Make Prefixes case-insensitive

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -68,9 +68,9 @@ Action     | Format, Examples
 
 <box type="warning" header="##### Notes">
 
-* The prefixes (e.g. `a/`, `s/` or `paid`) are case-insensitive, i.e. can use `a/`, `s/` or `pAId/` instead.
+* The prefixes (e.g. `a/`, `s/` or `paid`) are case-insensitive, i.e. you can use `a/`, `s/` or `pAId/` instead.
 
-* You should not use the prefixes in any other cases, for example, as a content of **ADDRESS**.
+* You should not use the prefixes in any other cases, e.g. as content of **ADDRESS**.
 </box>
 
 ## Features

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -66,6 +66,13 @@ Action     | Format, Examples
 **Settle** | `settle INDEX amount/AMOUNT`<br> e.g., `settle 1 amount/500.00`
 **Exit**   | `exit`
 
+<box type="warning" header="##### Notes">
+
+* The prefixes (e.g. `a/`, `s/` or `paid`) are case-insensitive, i.e. can use `a/`, `s/` or `pAId/` instead.
+
+* You should not use the prefixes in any other cases, for example, as a content of **ADDRESS**.
+</box>
+
 ## Features
 
 <box type="info">

--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -35,7 +35,7 @@ public class PayCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Updates the payment made by the student identified "
             + "by the index number used in the displayed Student list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_HOUR + "HOURS PAID\n"
+            + PREFIX_HOUR + "HOURS PAID (must be a positive multiple of 0.5)\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_HOUR + "3 ";
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -70,7 +70,8 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        String lowerCaseArgsString = argsString.toLowerCase();
+        int prefixIndex = lowerCaseArgsString.indexOf(" " + prefix, fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -8,7 +8,7 @@ public class Prefix {
     private final String prefix;
 
     public Prefix(String prefix) {
-        this.prefix = prefix;
+        this.prefix = prefix.toLowerCase(); // prefix must be in lowercase
     }
 
     public String getPrefix() {

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -37,6 +37,6 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) other;
-        return prefix.equals(otherPrefix.prefix);
+        return prefix.equals(otherPrefix.prefix.toLowerCase());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -57,22 +59,40 @@ public class CommandTestUtil {
     public static final String VALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "5.00";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
+    public static final String NAME_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_NAME.getPrefix())
+            + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
+    public static final String PHONE_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_PHONE.getPrefix())
+            + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
+    public static final String EMAIL_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_EMAIL.getPrefix())
+            + VALID_EMAIL_AMY;
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
+    public static final String ADDRESS_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_ADDRESS.getPrefix())
+            + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String SCHEDULE_DESC_AMY = " " + PREFIX_SCHEDULE + VALID_SCHEDULE_AMY;
+    public static final String SCHEDULE_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_SCHEDULE.getPrefix())
+            + VALID_SCHEDULE_AMY;
     public static final String SCHEDULE_DESC_BOB = " " + PREFIX_SCHEDULE + VALID_SCHEDULE_BOB;
     public static final String SUBJECT_DESC_AMY = " " + PREFIX_SUBJECT + VALID_SUBJECT_AMY;
+    public static final String SUBJECT_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_SUBJECT.getPrefix())
+            + VALID_SUBJECT_AMY;
     public static final String SUBJECT_DESC_BOB = " " + PREFIX_SUBJECT + VALID_SUBJECT_BOB;
     public static final String RATE_DESC_AMY = " " + PREFIX_RATE + VALID_RATE_AMY;
+    public static final String RATE_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_RATE.getPrefix())
+            + VALID_RATE_AMY;
     public static final String RATE_DESC_BOB = " " + PREFIX_RATE + VALID_RATE_BOB;
     public static final String PAID_AMOUNT_DESC_AMY = " " + PREFIX_PAID_AMOUNT + VALID_PAID_AMOUNT_AMY;
+    public static final String PAID_AMOUNT_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_PAID_AMOUNT.getPrefix())
+            + VALID_PAID_AMOUNT_AMY;
     public static final String PAID_AMOUNT_DESC_BOB = " " + PREFIX_PAID_AMOUNT + VALID_PAID_AMOUNT_BOB;
     public static final String OWED_AMOUNT_DESC_AMY = " " + PREFIX_OWED_AMOUNT + VALID_OWED_AMOUNT_AMY;
+    public static final String OWED_AMOUNT_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_OWED_AMOUNT.getPrefix())
+            + VALID_OWED_AMOUNT_AMY;
     public static final String OWED_AMOUNT_DESC_BOB = " " + PREFIX_OWED_AMOUNT + VALID_OWED_AMOUNT_BOB;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
@@ -165,5 +185,16 @@ public class CommandTestUtil {
 
         assertEquals(1, model.getFilteredStudentList().size());
     }
-
+    
+    /**
+     * Creates a mixed-case version of {@code s}.
+     * For example: "paidAmount/" becomes "pAiDaMoUnT/".
+     */
+    private static String createMixedCase(String s) {
+        return IntStream.range(0, s.length())
+                .mapToObj(i -> i % 2 == 0
+                        ? Character.toString(Character.toLowerCase(s.charAt(i)))
+                        : Character.toString(Character.toUpperCase(s.charAt(i))))
+                .collect(Collectors.joining());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -56,7 +56,10 @@ public class CommandTestUtil {
     public static final String VALID_OWED_AMOUNT_AMY = "500.00";
     public static final String VALID_OWED_AMOUNT_BOB = "300.25";
     public static final String VALID_HOUR_DESC = " " + PREFIX_HOUR + VALID_HOUR_AMY;
+    public static final String VALID_HOUR_DESC_MIXED_CASED = " " + createMixedCase(PREFIX_HOUR.getPrefix())
+            + VALID_HOUR_AMY;
     public static final String VALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "5.00";
+    public static final String VALID_AMOUNT_DESC_MIXED_CASE = " " + createMixedCase(PREFIX_AMOUNT.getPrefix()) + "5.00";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_AMY_MIXED_CASE = " " + createMixedCase(PREFIX_NAME.getPrefix())

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -188,7 +188,7 @@ public class CommandTestUtil {
 
         assertEquals(1, model.getFilteredStudentList().size());
     }
-    
+
     /**
      * Creates a mixed-case version of {@code s}.
      * For example: "paidAmount/" becomes "PaIdAmOuNt/".

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -188,13 +188,13 @@ public class CommandTestUtil {
     
     /**
      * Creates a mixed-case version of {@code s}.
-     * For example: "paidAmount/" becomes "pAiDaMoUnT/".
+     * For example: "paidAmount/" becomes "PaIdAmOuNt/".
      */
     private static String createMixedCase(String s) {
         return IntStream.range(0, s.length())
                 .mapToObj(i -> i % 2 == 0
-                        ? Character.toString(Character.toLowerCase(s.charAt(i)))
-                        : Character.toString(Character.toUpperCase(s.charAt(i))))
+                        ? Character.toString(Character.toUpperCase(s.charAt(i)))
+                        : Character.toString(Character.toLowerCase(s.charAt(i))))
                 .collect(Collectors.joining());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -93,10 +93,10 @@ public class AddCommandParserTest {
     @Test
     public void parse_allFieldsMixedCasePrefixes_success() {
         Student expectedStudent = new StudentBuilder(AMY).build();
-        
+
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY_MIXED_CASE + PHONE_DESC_AMY_MIXED_CASE
-        + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY_MIXED_CASE + SCHEDULE_DESC_AMY_MIXED_CASE
+            + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY_MIXED_CASE + SCHEDULE_DESC_AMY_MIXED_CASE
                 + SUBJECT_DESC_AMY_MIXED_CASE + RATE_DESC_AMY_MIXED_CASE + PAID_AMOUNT_DESC_AMY_MIXED_CASE
                 + OWED_AMOUNT_DESC_AMY_MIXED_CASE,
                 new AddCommand(expectedStudent));
@@ -105,7 +105,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_allFieldsPresentSomeMixedCasePrefixes_success() {
         Student expectedStudent = new StudentBuilder(AMY).build();
-        
+
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY_MIXED_CASE
                         + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY + SCHEDULE_DESC_AMY_MIXED_CASE

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -15,20 +17,27 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_RATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PAID_AMOUNT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PAID_AMOUNT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.PAID_AMOUNT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
@@ -78,6 +87,30 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + SCHEDULE_DESC_BOB + SUBJECT_DESC_BOB + RATE_DESC_BOB + PAID_AMOUNT_DESC_BOB
                         + OWED_AMOUNT_DESC_BOB,
+                new AddCommand(expectedStudent));
+    }
+
+    @Test
+    public void parse_allFieldsMixedCasePrefixes_success() {
+        Student expectedStudent = new StudentBuilder(AMY).build();
+        
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY_MIXED_CASE + PHONE_DESC_AMY_MIXED_CASE
+        + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY_MIXED_CASE + SCHEDULE_DESC_AMY_MIXED_CASE
+                + SUBJECT_DESC_AMY_MIXED_CASE + RATE_DESC_AMY_MIXED_CASE + PAID_AMOUNT_DESC_AMY_MIXED_CASE
+                + OWED_AMOUNT_DESC_AMY_MIXED_CASE,
+                new AddCommand(expectedStudent));
+    }
+
+    @Test
+    public void parse_allFieldsPresentSomeMixedCasePrefixes_success() {
+        Student expectedStudent = new StudentBuilder(AMY).build();
+        
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_AMY + PHONE_DESC_AMY_MIXED_CASE
+                        + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY + SCHEDULE_DESC_AMY_MIXED_CASE
+                        + SUBJECT_DESC_AMY + RATE_DESC_AMY + PAID_AMOUNT_DESC_AMY_MIXED_CASE
+                        + OWED_AMOUNT_DESC_AMY_MIXED_CASE,
                 new AddCommand(expectedStudent));
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -65,9 +65,7 @@ import seedu.address.model.student.OwedAmount;
 import seedu.address.model.student.Phone;
 import seedu.address.model.student.Rate;
 import seedu.address.model.student.Schedule;
-import seedu.address.model.student.Student;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
-import seedu.address.testutil.StudentBuilder;
 
 public class EditCommandParserTest {
 
@@ -241,10 +239,10 @@ public class EditCommandParserTest {
                 + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY_MIXED_CASE + NAME_DESC_AMY_MIXED_CASE
                 + SCHEDULE_DESC_AMY_MIXED_CASE + RATE_DESC_AMY_MIXED_CASE + OWED_AMOUNT_DESC_AMY_MIXED_CASE
                 + SUBJECT_DESC_AMY_MIXED_CASE + PAID_AMOUNT_DESC_AMY_MIXED_CASE;
-        
+
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-        
+
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -13,14 +15,21 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.OWED_AMOUNT_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PAID_AMOUNT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.RATE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.SCHEDULE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.SUBJECT_DESC_AMY_MIXED_CASE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -41,6 +50,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_STUDENT;
+import static seedu.address.testutil.TypicalStudents.AMY;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +65,9 @@ import seedu.address.model.student.OwedAmount;
 import seedu.address.model.student.Phone;
 import seedu.address.model.student.Rate;
 import seedu.address.model.student.Schedule;
+import seedu.address.model.student.Student;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
+import seedu.address.testutil.StudentBuilder;
 
 public class EditCommandParserTest {
 
@@ -220,5 +232,19 @@ public class EditCommandParserTest {
         assertParseFailure(parser, userInput,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_SCHEDULE, PREFIX_RATE, PREFIX_OWED_AMOUNT));
+    }
+
+    @Test
+    public void parse_allFieldsMixedCasePrefixes_success() {
+        Index targetIndex = INDEX_SECOND_STUDENT;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY_MIXED_CASE
+                + EMAIL_DESC_AMY_MIXED_CASE + ADDRESS_DESC_AMY_MIXED_CASE + NAME_DESC_AMY_MIXED_CASE
+                + SCHEDULE_DESC_AMY_MIXED_CASE + RATE_DESC_AMY_MIXED_CASE + OWED_AMOUNT_DESC_AMY_MIXED_CASE
+                + SUBJECT_DESC_AMY_MIXED_CASE + PAID_AMOUNT_DESC_AMY_MIXED_CASE;
+        
+        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(AMY).build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -112,13 +112,13 @@ public class FindCommandParserTest {
                 schedulePredicateKeywords,
                 namePredicateKeywords)
         );
-        
+
         // mixed-case prefix n/
         assertParseSuccess(parser, " N/Alice1 Bob d/Monday Tuesday", expectedFindCommand);
-        
+
         // mixed-case prefix d/
         assertParseSuccess(parser, " n/Alice1 Bob D/Monday Tuesday", expectedFindCommand);
-        
+
         // mixed-case both prefixes
         assertParseSuccess(parser, " N/Alice1 Bob D/Monday Tuesday", expectedFindCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -106,6 +106,22 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, " d/Monday Tuesday n/Alice1 Bob", expectedFindCommand);
     }
 
+    @Test
+    public void parse_validArgsMixedCasePrefixes_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(Arrays.asList(
+                schedulePredicateKeywords,
+                namePredicateKeywords)
+        );
+        
+        // mixed-case prefix n/
+        assertParseSuccess(parser, " N/Alice1 Bob d/Monday Tuesday", expectedFindCommand);
+        
+        // mixed-case prefix d/
+        assertParseSuccess(parser, " n/Alice1 Bob D/Monday Tuesday", expectedFindCommand);
+        
+        // mixed-case both prefixes
+        assertParseSuccess(parser, " N/Alice1 Bob D/Monday Tuesday", expectedFindCommand);
+    }
 
 
 

--- a/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.OweCommand;
-import seedu.address.logic.commands.PayCommand;
 
 public class OweCommandParserTest {
 
@@ -22,13 +21,13 @@ public class OweCommandParserTest {
             MESSAGE_INVALID_COMMAND_FORMAT, OweCommand.MESSAGE_USAGE);
 
     private OweCommandParser parser = new OweCommandParser();
-    
+
     @Test
     public void parse_validInput_success() {
         Index targetIndex = INDEX_FIRST_STUDENT;
         String userInput = targetIndex.getOneBased() + " " + PREFIX_HOUR + 1;
         OweCommand expectedCommand = new OweCommand(targetIndex, Double.parseDouble("1"));
-        
+
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
@@ -4,12 +4,17 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HOUR_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUR_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUR_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_HOUR_DESC_MIXED_CASED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUR;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.OweCommand;
+import seedu.address.logic.commands.PayCommand;
 
 public class OweCommandParserTest {
 
@@ -17,6 +22,15 @@ public class OweCommandParserTest {
             MESSAGE_INVALID_COMMAND_FORMAT, OweCommand.MESSAGE_USAGE);
 
     private OweCommandParser parser = new OweCommandParser();
+    
+    @Test
+    public void parse_validInput_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_HOUR + 1;
+        OweCommand expectedCommand = new OweCommand(targetIndex, Double.parseDouble("1"));
+        
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
 
     @Test
     public void parse_missingParts_failure() {
@@ -52,5 +66,12 @@ public class OweCommandParserTest {
     @Test
     public void parse_invalidHour_failure() {
         assertParseFailure(parser, "1" + INVALID_HOUR_DESC, ParserUtil.MESSAGE_INVALID_HOUR);
+    }
+
+    @Test
+    public void parse_validHourMixedCase_success() {
+        Index targetIndex = INDEX_FIRST_STUDENT;
+        OweCommand expectedCommand = new OweCommand(targetIndex, Double.parseDouble(VALID_HOUR_AMY));
+        assertParseSuccess(parser, "1" + VALID_HOUR_DESC_MIXED_CASED, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SettleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SettleCommandParserTest.java
@@ -77,9 +77,9 @@ public class SettleCommandParserTest {
     public void parse_validValueMixedCase_success() {
         SettleAmount settleAmount = new SettleAmount("5.00");
         String userInput = INDEX_FIRST_STUDENT.getOneBased() + " " + VALID_AMOUNT_DESC_MIXED_CASE;
-        
+
         SettleCommand expectedCommand = new SettleCommand(INDEX_FIRST_STUDENT, settleAmount);
-        
+
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SettleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SettleCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_DESC_MIXED_CASE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -70,5 +71,15 @@ public class SettleCommandParserTest {
         String userInput = INDEX_FIRST_STUDENT.getOneBased() + VALID_AMOUNT_DESC + INVALID_AMOUNT_DESC;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_AMOUNT));
+    }
+
+    @Test
+    public void parse_validValueMixedCase_success() {
+        SettleAmount settleAmount = new SettleAmount("5.00");
+        String userInput = INDEX_FIRST_STUDENT.getOneBased() + " " + VALID_AMOUNT_DESC_MIXED_CASE;
+        
+        SettleCommand expectedCommand = new SettleCommand(INDEX_FIRST_STUDENT, settleAmount);
+        
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }


### PR DESCRIPTION
What are the changes:
* `Prefix.java`: `prefix` String is made to lowercase
* `ArgumentTokenizer#findPrefixPosition`: change the whole argsString to lowercase to compare
* UG note