### PR TITLE
Fix bug: Valid phone number rejected

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -143,7 +143,7 @@ Adds a student to the address book.
 * **SCHEDULE** must be in the format of `DAY_OF_THE_WEEK`-`START_TIME`-`END_TIME`.
 * **DAY_OF_THE_WEEK** includes `Monday` `Tuesday` `Wednesday` `Thursday` `Friday` `Saturday` `Sunday`.
 * **START_TIME** and **END_TIME** are represented as `HHmm`.
-* **PHONE_NUMBER** should be 8 digits that starts with 6, 8 or 9.
+* **PHONE_NUMBER** should be 8 digits that starts with 3, 6, 8 or 9.
 * **RATE** is the tuition fee per hour. It must meet the following criteria:
   * Minimum: $0.01 (must be a positive value)
   * Maximum: $1000.00 (two decimal places allowed)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -144,6 +144,7 @@ Adds a student to the address book.
 * **DAY_OF_THE_WEEK** includes `Monday` `Tuesday` `Wednesday` `Thursday` `Friday` `Saturday` `Sunday`.
 * **START_TIME** and **END_TIME** are represented as `HHmm`.
 * **PHONE_NUMBER** should be 8 digits that starts with 3, 6, 8 or 9.
+> Reason: This constraint follows the convention set by Singapore's National Numbering Plan.
 * **RATE** is the tuition fee per hour. It must meet the following criteria:
   * Minimum: $0.01 (must be a positive value)
   * Maximum: $1000.00 (two decimal places allowed)

--- a/src/main/java/seedu/address/model/student/Phone.java
+++ b/src/main/java/seedu/address/model/student/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, start with 6, 8, or 9, and be exactly 8 digits long";
-    public static final String VALIDATION_REGEX = "^[689]\\d{7}$";
+            "Phone numbers should only contain numbers, start with 3, 6, 8, or 9, and be exactly 8 digits long";
+    public static final String VALIDATION_REGEX = "^[3689]\\d{7}$";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/model/student/PhoneTest.java
+++ b/src/test/java/seedu/address/model/student/PhoneTest.java
@@ -39,6 +39,7 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("63121534"));
         assertTrue(Phone.isValidPhone("83121534"));
+        assertTrue(Phone.isValidPhone("33121534"));
 
     }
 


### PR DESCRIPTION
closes #330 

![image](https://github.com/user-attachments/assets/d1ca6943-48e5-43b6-9b5b-b9a7ee96fecf)

Past PR: 
* This [PR](https://github.com/AY2425S1-CS2103T-F14a-1/tp/pull/80) is responsible for the phone number constraint. This PR missed out on the valid output where the phone number starts with 3.

Reason for change:
* Currently phone numbers starting with 3 are not allowed even though phone numbers starting with 3 are valid Singapore phone numbers.

Changes made include:
* updating regex to allow phone numbers starting with 3 
* error message
* user guide

Changes clarified and approved. Refer to this [issue](https://github.com/nus-cs2103-AY2425S1/forum/issues/676).

