### PR TITLE
Fix find accepting preamble bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -35,7 +35,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY);
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        if (trimmedArgs.isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -37,6 +37,25 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_preamblePresent_throwsParseException() {
+        // EP: preamble present
+        assertParseFailure(parser, " preamble",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // preamble with valid name arguments specified
+        assertParseFailure(parser, " preamble n/Alice Ben",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // preamble with valid day arguments specified
+        assertParseFailure(parser, " preamble d/Monday Tuesday",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // preamble with valid name and day arguments specified
+        assertParseFailure(parser, " preamble n/Alice Ben d/Monday Tuesday",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidInput_throwsParseException() {
         // EP: invalid input
         assertParseFailure(parser, " hello",

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -59,7 +59,7 @@ public class FindCommandParserTest {
     public void parse_invalidInput_throwsParseException() {
         // EP: invalid input
         assertParseFailure(parser, " hello",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_NO_PARAMETERS));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
     @Test
     public void parse_emptyNameArgument_throwsParseException() {


### PR DESCRIPTION
In the UG, we advertised that extra preambles will be ignored, only for all those available commands that **do not take in additional parameters** in our application. ![image](https://github.com/user-attachments/assets/b6d76b1d-ae0d-4185-a62b-c4a868dcb269)

The `find` command, which takes in additional parameters, ignores the extra preambles, which should not be the case.
`find` command should be in the format of `find [n/KEYWORD [MORE_KEYWORDS]] [d/DAY [MORE_DAYS]]`
eg. `find n/amy ben d/monday tuesday`

When there is extra preamble text, for example `find randomtext n/amy ben d/monday tuesday`
Expected: it should fail with an error message
Actual: it ignores the `randomtext` and function as though `find n/amy ben d/monday tuesday` was entered

The PR #118 is responsible for the updates of the behaviour of `find`. The command is checked to contain valid arguments for the prefixes `n/` or `d/`, if they are specified by the user. There is a bug in the check, as preamble text is ignored by the check.

Changes:
* Fix bug in find command parser to ensure preamble text is not present
* Add test case to test the code added

Clarified and approved in nus-cs2103-AY2425S1/forum#685
closes #357
closes #374
