### PR TITLE
Fix bug where settling 499.99 from 500.00 had no response

### DIFF
--- a/src/main/java/seedu/address/model/student/OwedAmount.java
+++ b/src/main/java/seedu/address/model/student/OwedAmount.java
@@ -1,6 +1,12 @@
 package seedu.address.model.student;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+
 
 /**
  * Represents a Student's owed tuition fee in the address book.
@@ -53,8 +59,14 @@ public class OwedAmount extends Fee {
      * @param amount The amount to be subtracted from the current owed amount.
      * @return A new {@code OwedAmount} object with the updated owed amount.
      */
-    public OwedAmount decreaseValue(SettleAmount amount) {
-        return new OwedAmount(Double.toString(super.value - amount.value));
+    public OwedAmount decreaseValue(SettleAmount amount) throws CommandException {
+        double roundedDecimal =
+                BigDecimal.valueOf(super.value - amount.value).setScale(2, RoundingMode.HALF_UP).doubleValue();
+        String newOwedAmount = Double.toString(roundedDecimal);
+        if (!isValidOwedAmount(newOwedAmount)) {
+            throw new CommandException(Messages.MESSAGE_LIMIT);
+        }
+        return new OwedAmount(newOwedAmount);
     }
 
     /**

--- a/src/main/java/seedu/address/model/student/PaidAmount.java
+++ b/src/main/java/seedu/address/model/student/PaidAmount.java
@@ -1,5 +1,7 @@
 package seedu.address.model.student;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
 
 import seedu.address.logic.Messages;
@@ -53,10 +55,12 @@ public class PaidAmount extends Fee {
      * @return A new {@code PaidAmount} object with the updated total amount.
      */
     public PaidAmount updateValue(SettleAmount amount) throws CommandException {
-        if (!isValidPaidAmount(Double.toString(super.value + amount.value))) {
+        double roundedDecimal =
+                BigDecimal.valueOf(super.value + amount.value).setScale(2, RoundingMode.HALF_UP).doubleValue();
+        if (!isValidPaidAmount(Double.toString(roundedDecimal))) {
             throw new CommandException(Messages.MESSAGE_LIMIT);
         }
-        return new PaidAmount(Double.toString(super.value + amount.value));
+        return new PaidAmount(Double.toString(roundedDecimal));
     }
 
     public double getValue() {

--- a/src/test/java/seedu/address/model/student/OwedAmountTest.java
+++ b/src/test/java/seedu/address/model/student/OwedAmountTest.java
@@ -8,6 +8,8 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
+
 public class OwedAmountTest {
 
     @Test
@@ -57,11 +59,29 @@ public class OwedAmountTest {
     }
 
     @Test
-    public void decreaseValue() {
+    // EP: boundary value 0.01 after decreasing owed amount
+    public void decreaseValue_boundary_value() throws CommandException {
+        OwedAmount owedAmount = new OwedAmount("500.00");
+
+        OwedAmount decreasedOwedAmount = owedAmount.decreaseValue(new SettleAmount("499.99"));
+        assertEquals("0.01", decreasedOwedAmount.toString());
+    }
+
+    @Test
+    public void decreaseValue_random_value() throws CommandException {
+        // EP: random value that could cause off by 0.01 inaccuracy
+        OwedAmount owedAmount = new OwedAmount("500.00");
+
+        OwedAmount decreasedOwedAmount = owedAmount.decreaseValue(new SettleAmount("499.13"));
+        assertEquals("0.87", decreasedOwedAmount.toString());
+    }
+
+    @Test
+    // EP: Invalid value after decreasing owe amount
+    public void decreaseValue_invalidAmount_throwCommandException() {
         OwedAmount owedAmount = new OwedAmount("10.00");
 
-        OwedAmount decreasedOwedAmount = owedAmount.decreaseValue(new SettleAmount("5.00"));
-        assertEquals("5.00", decreasedOwedAmount.toString());
+        assertThrows(CommandException.class, () -> owedAmount.decreaseValue(new SettleAmount("15.00")));
     }
 
     @Test


### PR DESCRIPTION
Settle command was not working as intended due
to inaccurate double arithmetic

Let's:
- Convert result of arithmetic to 2 d.p by 
half-rounding up the value
- Add tests to check for this error

Half-rounding up was used instead of rounding up
due to having accuracy issues when always 
rounding up as some decimals needed to be 
rounded down.

Closes #377

